### PR TITLE
Partial LLVM-6 support

### DIFF
--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -56,7 +56,9 @@
 
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
 
+#if LLVM_VERSION_MAJOR > 6
 #include "llvm/Transforms/Utils.h"
+#endif
 
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -1381,7 +1381,7 @@ Value *GradientUtils::invertPointerM(Value *oval, IRBuilder<> &BuilderM) {
     auto volatile_arg = ConstantInt::getFalse(oval->getContext());
 
 #if LLVM_VERSION_MAJOR == 6
-    auto align_arg = ConstantInt::get(Type::getInt32Ty(val->getContext()),
+    auto align_arg = ConstantInt::get(Type::getInt32Ty(oval->getContext()),
                                       antialloca->getAlignment());
     Value *args[] = {dst_arg, val_arg, len_arg, align_arg, volatile_arg};
 #else

--- a/enzyme/Enzyme/MustExitScalarEvolution.h
+++ b/enzyme/Enzyme/MustExitScalarEvolution.h
@@ -38,6 +38,8 @@ public:
   ScalarEvolution::ExitLimit computeExitLimit(const llvm::Loop *L,
                                               llvm::BasicBlock *ExitingBlock,
                                               bool AllowPredicates);
+
+  #if LLVM_VERSION_MAJOR >= 7
   ScalarEvolution::ExitLimit
   computeExitLimitFromCond(const llvm::Loop *L, llvm::Value *ExitCond, bool ExitIfTrue,
                            bool ControlsExit, bool AllowPredicates);
@@ -46,7 +48,6 @@ public:
   computeExitLimitFromCondCached(ExitLimitCacheTy &Cache, const llvm::Loop *L,
                                  llvm::Value *ExitCond, bool ExitIfTrue,
                                  bool ControlsExit, bool AllowPredicates);
-
   ScalarEvolution::ExitLimit
   computeExitLimitFromCondImpl(ExitLimitCacheTy &Cache, const llvm::Loop *L,
                                llvm::Value *ExitCond, bool ExitIfTrue,
@@ -55,6 +56,32 @@ public:
   ScalarEvolution::ExitLimit
   computeExitLimitFromICmp(const llvm::Loop *L, llvm::ICmpInst *ExitCond, bool ExitIfTrue,
                            bool ControlsExit, bool AllowPredicates = false);
+  #else
+  ScalarEvolution::ExitLimit
+  computeExitLimitFromCond(
+    const llvm::Loop *L, llvm::Value *ExitCond, llvm::BasicBlock *TBB, llvm::BasicBlock *FBB,
+    bool ControlsExit, bool AllowPredicates);
+
+  ScalarEvolution::ExitLimit
+  computeExitLimitFromCondCached(
+    ExitLimitCacheTy &Cache, const llvm::Loop *L, llvm::Value *ExitCond, llvm::BasicBlock *TBB,
+    llvm::BasicBlock *FBB, bool ControlsExit, bool AllowPredicates);
+
+  ScalarEvolution::ExitLimit
+  computeExitLimitFromCondImpl(
+    ExitLimitCacheTy &Cache, const llvm::Loop *L, llvm::Value *ExitCond, llvm::BasicBlock *TBB,
+    llvm::BasicBlock *FBB, bool ControlsExit, bool AllowPredicates);
+
+  ScalarEvolution::ExitLimit
+  computeExitLimitFromICmp(const llvm::Loop *L,
+                                            llvm::ICmpInst *ExitCond,
+                                            llvm::BasicBlock *TBB,
+                                            llvm::BasicBlock *FBB,
+                                            bool ControlsExit,
+                                            bool AllowPredicates=false);
+  #endif
+
+
 
   ScalarEvolution::ExitLimit howManyLessThans(const llvm::SCEV *LHS, const llvm::SCEV *RHS,
                                               const llvm::Loop *L, bool IsSigned,

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -62,6 +62,12 @@ template <typename T> static inline T max(T a, T b) {
     return a;
   return b;
 }
+/// Pick the maximum value
+template <typename T> static inline T min(T a, T b) {
+  if (a < b)
+    return a;
+  return b;
+}
 
 /// Output a set as a string
 template <typename T>


### PR DESCRIPTION
This restores Enzyme's ability to build against LLVM-6. We still should recommend against using LLVM-6, however, as it is not tested in CI (ubuntu doesn't have a package for) and a nontrivial amount of bugs in TBAA on the LLVM side.