### PR TITLE
Additional tools to ease debugging of errors produced by Enzyme

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -118,7 +118,9 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
   // of arguments
   if (isAllocationFunction(*F, TLI) || isDeallocationFunction(*F, TLI) ||
       Name == "__cxa_guard_acquire" || Name == "__cxa_guard_release" ||
-      Name == "__cxa_guard_abort" || Name == "printf" || Name == "puts")
+      Name == "__cxa_guard_abort" || Name == "printf" || Name == "puts" ||
+      Name == "__enzyme_float" || Name == "__enzyme_double" ||
+      Name == "__enzyme_integer" || Name == "__enzyme_pointer")
     return true;
 
   /// Use of the value as a non-src/dst in memset/memcpy/memmove is an inactive use
@@ -1036,7 +1038,9 @@ bool ActivityAnalyzer::isInstructionInactiveFromOrigin(TypeResults &TR, llvm::Va
           called->getName() == "_ZdlPv" || called->getName() == "_ZdlPvm" ||
           called->getName() == "__cxa_guard_acquire" ||
           called->getName() == "__cxa_guard_release" ||
-          called->getName() == "__cxa_guard_abort") {
+          called->getName() == "__cxa_guard_abort" ||
+          called->getName() == "__enzyme_float" || called->getName() == "__enzyme_double" ||
+          called->getName() == "__enzyme_integer" || called->getName() == "__enzyme_pointer") {
         return true;
       }
       // If requesting emptty unknown functions to be considered inactive, abide

--- a/enzyme/Enzyme/CMakeLists.txt
+++ b/enzyme/Enzyme/CMakeLists.txt
@@ -6,6 +6,9 @@ file(GLOB ENZYME_SRC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     "*.cpp"
 )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND ENZYME_SRC SCEV/ScalarEvolutionExpander.cpp)
 
 list(APPEND ENZYME_SRC  TypeAnalysis/TypeTree.cpp TypeAnalysis/TypeAnalysis.cpp TypeAnalysis/TypeAnalysisPrinter.cpp)

--- a/enzyme/Enzyme/Utils.cpp
+++ b/enzyme/Enzyme/Utils.cpp
@@ -32,6 +32,23 @@
 
 using namespace llvm;
 
+EnzymeFailure::EnzymeFailure(llvm::StringRef RemarkName,
+                             const llvm::DiagnosticLocation &Loc,
+                             const llvm::Instruction *CodeRegion) :
+                             DiagnosticInfoIROptimization(
+           EnzymeFailure::ID(), DS_Error, "enzyme", RemarkName,
+           *CodeRegion->getParent()->getParent(), Loc, CodeRegion) {}
+ 
+      llvm::DiagnosticKind EnzymeFailure::ID() {
+        static auto id = llvm::getNextAvailablePluginDiagnosticKind();
+        return (llvm::DiagnosticKind)id;
+      }
+
+/// \see DiagnosticInfoOptimizationBase::isEnabled.
+bool EnzymeFailure::isEnabled() const {
+  return true;
+}
+
 /// Convert a floating type to a string
 static inline std::string tofltstr(Type *T) {
   switch (T->getTypeID()) {


### PR DESCRIPTION
To follow #76 

Introduces helper utilities `__enzyme_float(ptr, size)` `__enzyme_double(ptr, size)` `__enzyme_integer(ptr, size)` and `__enzyme_pointer(ptr, size)` which explicitly informs type analysis of the type of [ptr, ptr+size).

Begins use of optimization remarks to provide debug information where type information not able to be determine. This allows source-code information about where type information needs to be injected.