### PR TITLE
Handle copysign

### DIFF
--- a/enzyme/Enzyme/ActivityAnalysis.cpp
+++ b/enzyme/Enzyme/ActivityAnalysis.cpp
@@ -168,6 +168,12 @@ bool ActivityAnalyzer::isFunctionArgumentConstant(CallInst *CI, Value *val) {
   if (F->getIntrinsicID() == Intrinsic::trap)
     return true;
 
+  /// Only the first argument (magnitude) of copysign is active
+  if (F->getIntrinsicID() == Intrinsic::copysign &&
+      CI->getArgOperand(0) != val) {
+    return true;
+  }
+
   /// Use of the value as a non-src/dst in memset/memcpy/memmove is an inactive
   /// use
   if (F->getIntrinsicID() == Intrinsic::memset && CI->getArgOperand(0) != val &&

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1704,6 +1704,7 @@ void TypeAnalyzer::visitIntrinsicInst(llvm::IntrinsicInst &I) {
 #if LLVM_VERSION_MAJOR >= 9
   case Intrinsic::experimental_vector_reduce_v2_fadd:
 #endif
+  case Intrinsic::copysign:
   case Intrinsic::maxnum:
   case Intrinsic::minnum:
   case Intrinsic::pow:

--- a/enzyme/test/Enzyme/copysign.ll
+++ b/enzyme/test/Enzyme/copysign.ll
@@ -1,0 +1,30 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+
+; Function Attrs: noinline nounwind readnone uwtable
+define double @tester(double %x, double %y) {
+entry:
+  %0 = tail call fast double @llvm.copysign.f64(double %x, double %y)
+  ret double %0
+}
+
+define double @test_derivative(double %x, double %y) {
+entry:
+  %0 = tail call double (double (double, double)*, ...) @__enzyme_autodiff(double (double, double)* nonnull @tester, double %x, double %y)
+  ret double %0
+}
+
+declare double @llvm.copysign.f64(double, double)
+
+; Function Attrs: nounwind
+declare double @__enzyme_autodiff(double (double, double)*, ...)
+
+; CHECK: define internal {{(dso_local )?}}{ double, double } @diffetester(double %x, double %y, double %[[differet:.+]])
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %0 = tail call fast double @llvm.copysign.f64(double 1.000000e+00, double %x)
+; CHECK-NEXT:   %1 = tail call fast double @llvm.copysign.f64(double 1.000000e+00, double %y)
+; CHECK-NEXT:   %2 = fmul fast double %0, %1
+; CHECK-NEXT:   %3 = fmul fast double %2, %[[differet]]
+; CHECK-NEXT:   %4 = insertvalue { double, double } undef, double %3, 0
+; CHECK-NEXT:   %5 = insertvalue { double, double } %4, double 0.000000e+00, 1
+; CHECK-NEXT:   ret { double, double } %5
+; CHECK-NEXT: }


### PR DESCRIPTION
The funny bithack in https://github.com/wsmoses/Enzyme.jl/issues/27 is caused by copysign, handling it here alongside a relevant cassette call in Enzyme.jl should resolve