### PR TITLE
Handle __sqrt_finite & shared memory

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3034,7 +3034,9 @@ public:
               lookup(gutils->getNewFromOriginal(orig_ops[0]), Builder2)};
           Type *tys[] = {orig_ops[0]->getType()};
           auto cal = cast<CallInst>(Builder2.CreateCall(
-              Intrinsic::getDeclaration(called->getParent(), Intrinsic::sqrt, tys), args));
+              Intrinsic::getDeclaration(called->getParent(), Intrinsic::sqrt,
+                                        tys),
+              args));
           cal->copyIRFlags(orig);
           cal->setAttributes(orig->getAttributes());
           cal->setCallingConv(orig->getCallingConv());

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -915,7 +915,8 @@ bool GradientUtils::legalRecompute(const Value *val,
           n == "lgamma_r" || n == "lgammaf_r" || n == "lgammal_r" ||
           n == "__lgamma_r_finite" || n == "__lgammaf_r_finite" ||
           n == "__lgammal_r_finite" || n == "tanh" || n == "tanhf" ||
-          n == "asin" || n == "asinf" || n == "asinl" || n == "__pow_finite") {
+          n == "asin" || n == "asinf" || n == "asinl" || n == "__pow_finite" ||
+          n == "__sqrt_finite") {
         return true;
       }
     }
@@ -1026,7 +1027,8 @@ bool GradientUtils::shouldRecompute(const Value *val,
       if (n == "lgamma" || n == "lgammaf" || n == "lgammal" ||
           n == "lgamma_r" || n == "lgammaf_r" || n == "lgammal_r" ||
           n == "__lgamma_r_finite" || n == "__lgammaf_r_finite" ||
-          n == "__lgammal_r_finite" || n == "tanh" || n == "tanhf") {
+          n == "__lgammal_r_finite" || n == "tanh" || n == "tanhf" ||
+          n == "__pow_finite" || n == "__sqrt_finite") {
         return true;
       }
     }
@@ -1035,6 +1037,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
   // cache a call, assuming its longer to run that
   if (isa<CallInst>(val)) {
     llvm::errs() << " caching call: " << *val << "\n";
+    //cast<CallInst>(val)->getCalledFunction()->dump();
     return false;
   }
 

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -2719,18 +2719,16 @@ void TypeAnalyzer::visitCallInst(CallInst &call) {
     CONSIDER(fmaf)
     CONSIDER(fmal)
 
-    if (ci->getName() == "__pow_finite") {
-      updateAnalysis(
-          call.getArgOperand(0),
-          TypeTree(ConcreteType(Type::getDoubleTy(call.getContext()))).Only(-1),
-          &call);
-      updateAnalysis(
-          call.getArgOperand(1),
-          TypeTree(ConcreteType(Type::getDoubleTy(call.getContext()))).Only(-1),
-          &call);
+    if (ci->getName() == "__pow_finite" || ci->getName() == "__sqrt_finite") {
+      for(int i=0; i<call.getNumArgOperands(); ++i) {
+        updateAnalysis(
+            call.getArgOperand(i),
+            TypeTree(ConcreteType(call.getArgOperand(i)->getType())).Only(-1),
+            &call);
+      }
       updateAnalysis(
           &call,
-          TypeTree(ConcreteType(Type::getDoubleTy(call.getContext()))).Only(-1),
+          TypeTree(ConcreteType(call.getType())).Only(-1),
           &call);
       return;
     }

--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -2720,16 +2720,14 @@ void TypeAnalyzer::visitCallInst(CallInst &call) {
     CONSIDER(fmal)
 
     if (ci->getName() == "__pow_finite" || ci->getName() == "__sqrt_finite") {
-      for(int i=0; i<call.getNumArgOperands(); ++i) {
+      for (int i = 0; i < call.getNumArgOperands(); ++i) {
         updateAnalysis(
             call.getArgOperand(i),
             TypeTree(ConcreteType(call.getArgOperand(i)->getType())).Only(-1),
             &call);
       }
-      updateAnalysis(
-          &call,
-          TypeTree(ConcreteType(call.getType())).Only(-1),
-          &call);
+      updateAnalysis(&call, TypeTree(ConcreteType(call.getType())).Only(-1),
+                     &call);
       return;
     }
     if (ci->getName() == "__lgamma_r_finite") {

--- a/enzyme/test/Enzyme/cuda.ll
+++ b/enzyme/test/Enzyme/cuda.ll
@@ -1,4 +1,4 @@
-; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -gvn -adce -instsimplify -early-cse-memssa -simplifycfg -S | FileCheck %s
+; RUN: if [ %llvmver -ge 9 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -gvn -adce -instsimplify -early-cse-memssa -simplifycfg -S | FileCheck %s; fi
 
 ; ModuleID = 'cuda.cu'
 source_filename = "cuda.cu"
@@ -79,6 +79,6 @@ attributes #3 = { nounwind }
 ; CHECK-NEXT:   %0 = load double, double* %"gep'ipg", align 4
 ; CHECK-NEXT:   store double 0.000000e+00, double* %"gep'ipg", align 4
 ; CHECK-NEXT:   %m0diffeld = fmul fast double %0, %x
-; CHECK-NEXT:   %1 = call fast double @llvm.nvvm.atomic.add.gen.f.sys.f64.p0f64(double* %"g0'ipg", double %m0diffeld)
+; CHECK-NEXT:   %1 = atomicrmw fadd double* %"g0'ipg", double %m0diffeld monotonic
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/sharedmem.ll
+++ b/enzyme/test/Enzyme/sharedmem.ll
@@ -1,0 +1,130 @@
+; RUN: if [ %llvmver -ge 9 ]; then %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s; fi
+
+source_filename = "cudaMM.cu"
+target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+@_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a = internal unnamed_addr addrspace(3) global float undef, align 4
+
+; Function Attrs: convergent nounwind
+define dso_local void @_Z19gpu_square_elem_mulPfS_S_m(float* nocapture readonly %arg, float* nocapture readonly %arg1, float* nocapture %arg2, i64 %arg3) {
+bb:
+  %tmp = tail call i32 @llvm.nvvm.read.ptx.sreg.ctaid.y() #4, !range !10
+  %tmp4 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.y() #4, !range !11
+  %tmp5 = add nuw nsw i32 %tmp4, %tmp
+  %tmp6 = zext i32 %tmp5 to i64
+  %tmp7 = tail call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #4, !range !12
+  %tmp8 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x() #4, !range !11
+  %tmp9 = add nuw i32 %tmp8, %tmp7
+  %tmp10 = zext i32 %tmp9 to i64
+  %tmp11 = mul i64 %tmp6, %arg3
+  %tmp12 = add i64 %tmp11, %tmp10
+  %tmp13 = getelementptr inbounds float, float* %arg, i64 %tmp12
+  %tmp14 = bitcast float* %tmp13 to i32*
+  %tmp15 = load i32, i32* %tmp14, align 4, !tbaa !13
+  store i32 %tmp15, i32* addrspacecast (i32 addrspace(3)* bitcast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a to i32 addrspace(3)*) to i32*), align 4, !tbaa !13
+  %tmp16 = getelementptr inbounds float, float* %arg1, i64 %tmp12
+  %tmp17 = load float, float* %tmp16, align 4, !tbaa !13
+  tail call void @llvm.nvvm.barrier0()
+  %tmp18 = load float, float* addrspacecast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a to float*), align 4, !tbaa !13
+  %tmp19 = fmul contract float %tmp17, %tmp18
+  %tmp20 = getelementptr inbounds float, float* %arg2, i64 %tmp12
+  store float %tmp19, float* %tmp20, align 4, !tbaa !13
+  ret void
+}
+
+; Function Attrs: convergent nounwind
+declare void @llvm.nvvm.barrier0() #2
+
+define void @_Z4axpyPfS_S_S_S_S_m(float* %a, float* %b, float* %c, float* %d, float* %e, float* %f, i64 %sz) {
+bb:
+  tail call void @_Z17__enzyme_autodiffPvS_S_S_S_S_S_m(i8* bitcast (void (float*, float*, float*, i64)* @_Z19gpu_square_elem_mulPfS_S_m to i8*), float* %a, float* %b, float* %c, float* %d, float* %e, float* %f, i64 %sz)
+  ret void
+}
+
+declare void @_Z17__enzyme_autodiffPvS_S_S_S_S_S_m(i8*, float*, float*, float*, float*, float*, float*, i64)
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.y() #3
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.tid.y() #3
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #3
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #3
+
+; Function Attrs: nounwind readnone
+declare i32 @llvm.nvvm.read.ptx.sreg.nctaid.x() #3
+
+attributes #0 = { argmemonly nounwind willreturn }
+attributes #2 = { convergent nounwind }
+attributes #3 = { nounwind readnone }
+attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2}
+!nvvm.annotations = !{!3, !4, !5, !4, !6, !6, !6, !6, !7, !7, !6}
+!llvm.ident = !{!8}
+!nvvmir.version = !{!9}
+
+!0 = !{i32 2, !"SDK Version", [2 x i32] [i32 10, i32 1]}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 4, !"nvvm-reflect-ftz", i32 0}
+!3 = !{void (float*, float*, float*, float*, float*, float*, i64)* @_Z4axpyPfS_S_S_S_S_m, !"kernel", i32 1}
+!4 = !{null, !"align", i32 8}
+!5 = !{null, !"align", i32 8, !"align", i32 65544, !"align", i32 131080}
+!6 = !{null, !"align", i32 16}
+!7 = !{null, !"align", i32 16, !"align", i32 65552, !"align", i32 131088}
+!8 = !{!"Ubuntu clang version 10.0.1-++20200809072545+ef32c611aa2-1~exp1~20200809173142.193"}
+!9 = !{i32 1, i32 4}
+!10 = !{i32 0, i32 65535}
+!11 = !{i32 0, i32 1024}
+!12 = !{i32 0, i32 2147483647}
+!13 = !{!14, !14, i64 0}
+!14 = !{!"float", !15, i64 0}
+!15 = !{!"omnipotent char", !16, i64 0}
+!16 = !{!"Simple C++ TBAA"}
+
+; CHECK: define internal void @diffe_Z19gpu_square_elem_mulPfS_S_m(float* nocapture readonly %arg, float* nocapture %"arg'", float* nocapture readonly %arg1, float* nocapture %"arg1'", float* nocapture %arg2, float* nocapture %"arg2'", i64 %arg3)
+; CHECK-NEXT: bb:
+; CHECK-NEXT:   store float 0.000000e+00, float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a_shadow
+; CHECK-NEXT:   call void @llvm.nvvm.barrier0()
+; CHECK-NEXT:   %tmp = tail call i32 @llvm.nvvm.read.ptx.sreg.ctaid.y() #2, !range !12
+; CHECK-NEXT:   %tmp4 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.y() #2, !range !13
+; CHECK-NEXT:   %tmp5 = add nuw nsw i32 %tmp4, %tmp
+; CHECK-NEXT:   %tmp6 = zext i32 %tmp5 to i64
+; CHECK-NEXT:   %tmp7 = tail call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #2, !range !14
+; CHECK-NEXT:   %tmp8 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2, !range !13
+; CHECK-NEXT:   %tmp9 = add nuw i32 %tmp8, %tmp7
+; CHECK-NEXT:   %tmp10 = zext i32 %tmp9 to i64
+; CHECK-NEXT:   %tmp11 = mul i64 %tmp6, %arg3
+; CHECK-NEXT:   %tmp12 = add i64 %tmp11, %tmp10
+; CHECK-NEXT:   %"tmp13'ipg" = getelementptr inbounds float, float* %"arg'", i64 %tmp12
+; CHECK-NEXT:   %tmp13 = getelementptr inbounds float, float* %arg, i64 %tmp12
+; CHECK-NEXT:   %tmp14 = bitcast float* %tmp13 to i32*
+; CHECK-NEXT:   %tmp15 = load i32, i32* %tmp14, align 4, !tbaa !15
+; CHECK-NEXT:   store i32 %tmp15, i32* addrspacecast (i32 addrspace(3)* bitcast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a to i32 addrspace(3)*) to i32*), align 4, !tbaa !15
+; CHECK-NEXT:   %"tmp16'ipg" = getelementptr inbounds float, float* %"arg1'", i64 %tmp12
+; CHECK-NEXT:   %tmp16 = getelementptr inbounds float, float* %arg1, i64 %tmp12
+; CHECK-NEXT:   %tmp17 = load float, float* %tmp16, align 4, !tbaa !15
+; CHECK-NEXT:   tail call void @llvm.nvvm.barrier0()
+; CHECK-NEXT:   %tmp18 = load float, float* addrspacecast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a to float*), align 4, !tbaa !15
+; CHECK-NEXT:   %tmp19 = fmul contract float %tmp17, %tmp18
+; CHECK-NEXT:   %"tmp20'ipg" = getelementptr inbounds float, float* %"arg2'", i64 %tmp12
+; CHECK-NEXT:   %tmp20 = getelementptr inbounds float, float* %arg2, i64 %tmp12
+; CHECK-NEXT:   store float %tmp19, float* %tmp20, align 4, !tbaa !15
+; CHECK-NEXT:   %0 = load float, float* %"tmp20'ipg", align 4
+; CHECK-NEXT:   store float 0.000000e+00, float* %"tmp20'ipg", align 4
+; CHECK-NEXT:   %m0diffetmp17 = fmul fast float %0, %tmp18
+; CHECK-NEXT:   %m1diffetmp18 = fmul fast float %0, %tmp17
+; CHECK-NEXT:   %1 = atomicrmw fadd float* addrspacecast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a_shadow to float*), float %m1diffetmp18 monotonic
+; CHECK-NEXT:   tail call void @llvm.nvvm.barrier0()
+; CHECK-NEXT:   %2 = atomicrmw fadd float* %"tmp16'ipg", float %m0diffetmp17 monotonic
+; CHECK-NEXT:   %3 = load i32, i32* addrspacecast (i32 addrspace(3)* bitcast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a_shadow to i32 addrspace(3)*) to i32*), align 4
+; CHECK-NEXT:   store i32 0, i32* addrspacecast (i32 addrspace(3)* bitcast (float addrspace(3)* @_ZZ19gpu_square_elem_mulPfS_S_mE6tile_a_shadow to i32 addrspace(3)*) to i32*), align 4
+; CHECK-NEXT:   %4 = bitcast i32 %3 to float
+; CHECK-NEXT:   %5 = atomicrmw fadd float* %"tmp13'ipg", float %4 monotonic
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }


### PR DESCRIPTION
These calls get emitted sometimes in later LLVM versions, even with -ffast-math. We should generically support all the variants of libm functions (ideally by raising/lowering to a common form), but this adds a necessary function for now.