### PR TITLE
Distribute minimal source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+/LICENSE export-ignore
+/Readme.md export-ignore
+/clang export-ignore
+/clang-tools-extra export-ignore
+/compiler-rt export-ignore
+/contrib export-ignore
+/debuginfo-tests export-ignore
+/libcxx export-ignore
+/libcxxabi export-ignore
+/libunwind export-ignore
+/lld export-ignore
+/lldb export-ignore
+/llvm export-ignore
+/openmp export-ignore
+/polly export-ignore
+/tests export-ignore
+/enzyme/benchmarks export-ignore

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y python-pip autoconf cmake gcc g++ libtool gfortran libblas-dev llvm-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libeigen3-dev libboost-dev
           sudo pip install lit
           sudo touch /usr/lib/llvm-${{ matrix.llvm }}/bin/yaml-bench
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
           fetch-depth: 1
     - name: mkdir

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y autoconf cmake gcc g++ libtool gfortran llvm-${{ matrix.llvm }}-dev libomp-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libeigen3-dev libboost-dev
           sudo pip install lit
           sudo touch /usr/lib/llvm-${{ matrix.llvm }}/bin/yaml-bench
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
           fetch-depth: 1
     - name: mkdir

--- a/.github/workflows/enzyme-linux.yml
+++ b/.github/workflows/enzyme-linux.yml
@@ -33,7 +33,7 @@ jobs:
           fi
           sudo pip install lit
           sudo touch /usr/lib/llvm-${{ matrix.llvm }}/bin/yaml-bench
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
           fetch-depth: 1
     - name: mkdir

--- a/.github/workflows/enzyme-mac.yml
+++ b/.github/workflows/enzyme-mac.yml
@@ -21,7 +21,7 @@ jobs:
           #sudo apt-get remove  -y llvm-${{ matrix.llvm }}-dev llvm-${{ matrix.llvm }}-tools 
           brew install llvm@${{ matrix.llvm }} autoconf cmake gcc
           sudo pip3 install lit
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
           fetch-depth: 1
     - name: mkdir

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
           fetch-depth: 1
     - uses: DoozyX/clang-format-lint-action@v0.11

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -96,4 +96,4 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
 add_subdirectory(Enzyme)
 add_subdirectory(test)
-add_subdirectory(benchmarks)
+#add_subdirectory(benchmarks)

--- a/enzyme/CMakeLists.txt
+++ b/enzyme/CMakeLists.txt
@@ -96,4 +96,9 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
 add_subdirectory(Enzyme)
 add_subdirectory(test)
-#add_subdirectory(benchmarks)
+
+# The benchmarks data are not in git-exported source archives to minimize size.
+# Only add the benchmarks if the directory exists.
+if (EXISTS benchmarks)
+    add_subdirectory(benchmarks)
+endif()


### PR DESCRIPTION
It takes a while to check out this repo, which is quite large. Uncompressed the repo size is 2 GB, which makes it a bit slow to build dockerfiles with. To cut down on the initial download for users, this PR sets git attributes such that only the files within the `enzyme` subdirectory are exported with `git-archive`. The `enzyme/benchmarks` folder is also ignored since it is quite large. The resulting tar file is <1 MB in size.

See #119.