### PR TITLE
Fix Command line C ABI & introduce primitive malloc coalesing

### DIFF
--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -154,6 +154,11 @@ void EnzymeSetCLInteger(void *ptr, int64_t val) {
   cl->setValue((int)val);
 }
 
+int64_t EnzymeGetCLInteger(void *ptr) {
+  auto cl = (llvm::cl::opt<int> *)ptr;
+  return (int64_t)cl->getValue();
+}
+
 EnzymeLogicRef CreateEnzymeLogic() {
   return (EnzymeLogicRef)(new EnzymeLogic());
 }

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -140,13 +140,18 @@ FnTypeInfo eunwrap(CFnTypeInfo CTI, llvm::Function *F) {
 extern "C" {
 
 void EnzymeSetCLBool(void *ptr, uint8_t val) {
-  auto &cl = (llvm::cl::opt<bool> &)ptr;
-  cl.setValue((bool)val);
+  auto cl = (llvm::cl::opt<bool> *)ptr;
+  cl->setValue((bool)val);
+}
+
+uint8_t EnzymeGetCLBool(void *ptr) {
+  auto cl = (llvm::cl::opt<bool> *)ptr;
+  return (uint8_t)(bool)cl->getValue();
 }
 
 void EnzymeSetCLInteger(void *ptr, int64_t val) {
-  auto &cl = (llvm::cl::opt<int> &)ptr;
-  cl.setValue((int)val);
+  auto cl = (llvm::cl::opt<int> *)ptr;
+  cl->setValue((int)val);
 }
 
 EnzymeLogicRef CreateEnzymeLogic() {

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -124,6 +124,9 @@ static cl::opt<int>
     EnzymeInlineCount("enzyme-inline-count", cl::init(10000), cl::Hidden,
                       cl::desc("Limit of number of functions to inline"));
 
+cl::opt<bool> EnzymeCoalese("enzyme-coalese", cl::init(false), cl::Hidden,
+                            cl::desc("Whether to coalese memory allocations"));
+
 #if LLVM_VERSION_MAJOR >= 8
 static cl::opt<bool> EnzymePHIRestructure(
     "enzyme-phi-restructure", cl::init(false), cl::Hidden,
@@ -1574,6 +1577,8 @@ void PreProcessCache::optimizeIntermediate(Function *F) {
     PreservedAnalyses PA;
     FAM.invalidate(*F, PA);
   }
+  if (EnzymeCoalese)
+    CoaleseTrivialMallocs(*F, FAM.getResult<DominatorTreeAnalysis>(*F));
   // DCEPass().run(*F, AM);
 }
 

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -699,6 +699,7 @@ allUnsyncdPredecessorsOf(llvm::Instruction *inst,
 }
 
 #include "llvm/Analysis/LoopInfo.h"
+
 static inline void
 /// Call the function f for all instructions that happen between inst1 and inst2
 /// If the function returns true, the iteration will early exit


### PR DESCRIPTION
This should enable the use of the relevant CL flags without needing to be on a custom branch.