### PR TITLE
Refactor top level

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -275,9 +275,7 @@ public:
             Mode == DerivativeMode::ForwardMode
                 ? false
                 : is_value_needed_in_reverse<ValueType::ShadowPtr>(
-                      TR, gutils, &I,
-                      /*toplevel*/ Mode == DerivativeMode::ReverseModeCombined,
-                      oldUnreachable);
+                      TR, gutils, &I, Mode, oldUnreachable);
 
         switch (Mode) {
 
@@ -333,9 +331,7 @@ public:
         Mode == DerivativeMode::ForwardMode
             ? false
             : is_value_needed_in_reverse<ValueType::Primal>(
-                  TR, gutils, &I,
-                  /*toplevel*/ Mode == DerivativeMode::ReverseModeCombined,
-                  oldUnreachable);
+                  TR, gutils, &I, Mode, oldUnreachable);
     //! Store loads that need to be cached for use in reverse pass
     if (cache_reads_always ||
         (!cache_reads_never && can_modref && primalNeededInReverse)) {
@@ -4011,9 +4007,7 @@ public:
       // TO FREE'ing
       if (Mode != DerivativeMode::ReverseModeCombined) {
         if ((is_value_needed_in_reverse<ValueType::Primal>(
-                 TR, gutils, orig,
-                 /*topLevel*/ Mode == DerivativeMode::ReverseModeCombined,
-                 oldUnreachable) &&
+                 TR, gutils, orig, Mode, oldUnreachable) &&
              !gutils->unnecessaryIntermediates.count(orig)) ||
             hasMetadata(orig, "enzyme_fromstack")) {
           Value *nop = gutils->cacheForReverse(BuilderZ, op,
@@ -4585,9 +4579,7 @@ public:
 
           if (Mode == DerivativeMode::ReverseModePrimal &&
               is_value_needed_in_reverse<ValueType::Primal>(
-                  TR, gutils, orig,
-                  /*topLevel*/ Mode == DerivativeMode::ReverseModeCombined,
-                  oldUnreachable) &&
+                  TR, gutils, orig, Mode, oldUnreachable) &&
               !gutils->unnecessaryIntermediates.count(orig)) {
             gutils->cacheForReverse(BuilderZ, dcall,
                                     getIndex(orig, CacheType::Self));
@@ -4620,8 +4612,7 @@ public:
 
         if (subretused) {
           if (is_value_needed_in_reverse<ValueType::Primal>(
-                  TR, gutils, orig, Mode == DerivativeMode::ReverseModeCombined,
-                  oldUnreachable) &&
+                  TR, gutils, orig, Mode, oldUnreachable) &&
               !gutils->unnecessaryIntermediates.count(orig)) {
             cachereplace = BuilderZ.CreatePHI(orig->getType(), 1,
                                               orig->getName() + "_tmpcacheB");
@@ -4713,8 +4704,7 @@ public:
       if (/*!topLevel*/ Mode != DerivativeMode::ReverseModeCombined &&
           subretused && !orig->doesNotAccessMemory()) {
         if (is_value_needed_in_reverse<ValueType::Primal>(
-                TR, gutils, orig, Mode == DerivativeMode::ReverseModeCombined,
-                oldUnreachable) &&
+                TR, gutils, orig, Mode, oldUnreachable) &&
             !gutils->unnecessaryIntermediates.count(orig)) {
           assert(!replaceFunction);
           cachereplace = BuilderZ.CreatePHI(orig->getType(), 1,

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -2535,7 +2535,6 @@ public:
       }
 
       auto argType = argi->getType();
-      bool fwdMode = Mode == DerivativeMode::ForwardMode;
 
       if (!argType->isFPOrFPVectorTy() &&
           TR.query(call.getArgOperand(i)).Inner0().isPossiblePointer()) {
@@ -2567,13 +2566,13 @@ public:
 
         // Note sometimes whattype mistakenly says something should be constant
         // [because composed of integer pointers alone]
-        assert(whatType(argType, fwdMode) == DIFFE_TYPE::DUP_ARG ||
-               whatType(argType, fwdMode) == DIFFE_TYPE::CONSTANT);
+        assert(whatType(argType, Mode) == DIFFE_TYPE::DUP_ARG ||
+               whatType(argType, Mode) == DIFFE_TYPE::CONSTANT);
       } else {
         assert(0 && "out for omp not handled");
         argsInverted.push_back(DIFFE_TYPE::OUT_DIFF);
-        assert(whatType(argType, fwdMode) == DIFFE_TYPE::OUT_DIFF ||
-               whatType(argType, fwdMode) == DIFFE_TYPE::CONSTANT);
+        assert(whatType(argType, Mode) == DIFFE_TYPE::OUT_DIFF ||
+               whatType(argType, Mode) == DIFFE_TYPE::CONSTANT);
       }
     }
 
@@ -4300,7 +4299,6 @@ public:
       }
 
       auto argType = argi->getType();
-      bool fwdMode = Mode == DerivativeMode::ForwardMode;
 
       if (!argType->isFPOrFPVectorTy() &&
           (TR.query(orig->getArgOperand(i)).Inner0().isPossiblePointer() ||
@@ -4333,14 +4331,14 @@ public:
 
         // Note sometimes whattype mistakenly says something should be constant
         // [because composed of integer pointers alone]
-        assert(whatType(argType, fwdMode) == DIFFE_TYPE::DUP_ARG ||
-               whatType(argType, fwdMode) == DIFFE_TYPE::CONSTANT);
+        assert(whatType(argType, Mode) == DIFFE_TYPE::DUP_ARG ||
+               whatType(argType, Mode) == DIFFE_TYPE::CONSTANT);
       } else {
         if (foreignFunction)
           assert(!argType->isIntOrIntVectorTy());
         argsInverted.push_back(DIFFE_TYPE::OUT_DIFF);
-        assert(whatType(argType, fwdMode) == DIFFE_TYPE::OUT_DIFF ||
-               whatType(argType, fwdMode) == DIFFE_TYPE::CONSTANT);
+        assert(whatType(argType, Mode) == DIFFE_TYPE::OUT_DIFF ||
+               whatType(argType, Mode) == DIFFE_TYPE::CONSTANT);
       }
     }
     if (called) {

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -241,7 +241,7 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
     EnzymeLogicRef Logic, LLVMValueRef todiff, CDIFFE_TYPE retType,
     CDIFFE_TYPE *constant_args, size_t constant_args_size,
     EnzymeTypeAnalysisRef TA, uint8_t returnValue, uint8_t dretUsed,
-    uint8_t topLevel, LLVMTypeRef additionalArg, CFnTypeInfo typeInfo,
+    CDerivativeMode mode, LLVMTypeRef additionalArg, CFnTypeInfo typeInfo,
     uint8_t *_uncacheable_args, size_t uncacheable_args_size,
     EnzymeAugmentedReturnPtr augmented, uint8_t AtomicAdd, uint8_t PostOpt) {
   std::vector<DIFFE_TYPE> nconstant_args((DIFFE_TYPE *)constant_args,
@@ -256,10 +256,9 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
   }
   return wrap(eunwrap(Logic).CreatePrimalAndGradient(
       cast<Function>(unwrap(todiff)), (DIFFE_TYPE)retType, nconstant_args,
-      eunwrap(TA).TLI, eunwrap(TA), returnValue, dretUsed, topLevel,
+      eunwrap(TA).TLI, eunwrap(TA), returnValue, dretUsed, (DerivativeMode)mode,
       unwrap(additionalArg), eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
-      uncacheable_args, eunwrap(augmented), AtomicAdd, /*fwdMode*/ false,
-      PostOpt));
+      uncacheable_args, eunwrap(augmented), AtomicAdd, PostOpt));
 }
 EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
     EnzymeLogicRef Logic, LLVMValueRef todiff, CDIFFE_TYPE retType,

--- a/enzyme/Enzyme/CApi.h
+++ b/enzyme/Enzyme/CApi.h
@@ -109,13 +109,21 @@ typedef enum {
                      // but don't need the forward
 } CDIFFE_TYPE;
 
+typedef enum {
+  DEM_ForwardMode = 0,
+  DEM_ReverseModePrimal = 1,
+  DEM_ReverseModeGradient = 2,
+  DEM_ReverseModeCombined = 3,
+} CDerivativeMode;
+
 LLVMValueRef EnzymeCreatePrimalAndGradient(
     EnzymeLogicRef, LLVMValueRef todiff, CDIFFE_TYPE retType,
     CDIFFE_TYPE *constant_args, size_t constant_args_size,
     EnzymeTypeAnalysisRef TA, uint8_t returnValue, uint8_t dretUsed,
-    uint8_t topLevel, LLVMTypeRef additionalArg, struct CFnTypeInfo typeInfo,
-    uint8_t *_uncacheable_args, size_t uncacheable_args_size,
-    EnzymeAugmentedReturnPtr augmented, uint8_t AtomicAdd, uint8_t PostOpt);
+    CDerivativeMode mode, LLVMTypeRef additionalArg,
+    struct CFnTypeInfo typeInfo, uint8_t *_uncacheable_args,
+    size_t uncacheable_args_size, EnzymeAugmentedReturnPtr augmented,
+    uint8_t AtomicAdd, uint8_t PostOpt);
 
 EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
     EnzymeLogicRef, LLVMValueRef todiff, CDIFFE_TYPE retType,

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -215,7 +215,7 @@ public:
               cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
           continue;
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else if (isa<LoadInst>(res) &&
                  isa<ConstantExpr>(cast<LoadInst>(res)->getOperand(0)) &&
@@ -250,7 +250,7 @@ public:
               cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
           continue;
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else if (isa<GlobalVariable>(res)) {
         auto gv = cast<GlobalVariable>(res);
@@ -272,7 +272,7 @@ public:
           ++i;
           res = CI->getArgOperand(i);
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else if (isa<ConstantExpr>(res) && cast<ConstantExpr>(res)->isCast() &&
                  isa<GlobalVariable>(cast<ConstantExpr>(res)->getOperand(0))) {
@@ -295,7 +295,7 @@ public:
           ++i;
           res = CI->getArgOperand(i);
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else if (isa<CastInst>(res) && cast<CastInst>(res) &&
                  isa<AllocaInst>(cast<CastInst>(res)->getOperand(0))) {
@@ -318,7 +318,7 @@ public:
           ++i;
           res = CI->getArgOperand(i);
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else if (isa<AllocaInst>(res)) {
         auto gv = cast<AllocaInst>(res);
@@ -340,10 +340,10 @@ public:
           ++i;
           res = CI->getArgOperand(i);
         } else {
-          ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+          ty = whatType(PTy, mode);
         }
       } else
-        ty = whatType(PTy, mode == DerivativeMode::ForwardMode);
+        ty = whatType(PTy, mode);
 
       constants.push_back(ty);
 
@@ -440,8 +440,7 @@ public:
         mode != DerivativeMode::ForwardMode &&
         cast<Function>(fn)->getReturnType()->isFPOrFPVectorTy();
 
-    DIFFE_TYPE retType = whatType(cast<Function>(fn)->getReturnType(),
-                                  mode == DerivativeMode::ForwardMode);
+    DIFFE_TYPE retType = whatType(cast<Function>(fn)->getReturnType(), mode);
 
     std::map<Argument *, bool> volatile_args;
     FnTypeInfo type_args(cast<Function>(fn));

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -478,10 +478,9 @@ public:
     case DerivativeMode::ReverseModeCombined:
       newFunc = Logic.CreatePrimalAndGradient(
           cast<Function>(fn), retType, constants, TLI, TA,
-          /*should return*/ false, /*dretPtr*/ false, /*topLevel*/ true,
+          /*should return*/ false, /*dretPtr*/ false, mode,
           /*addedType*/ nullptr, type_args, volatile_args,
-          /*index mapping*/ nullptr, AtomicAdd,
-          mode == DerivativeMode::ForwardMode, PostOpt);
+          /*index mapping*/ nullptr, AtomicAdd, PostOpt);
       break;
     case DerivativeMode::ReverseModePrimal:
     case DerivativeMode::ReverseModeGradient: {
@@ -515,9 +514,8 @@ public:
       else
         newFunc = Logic.CreatePrimalAndGradient(
             cast<Function>(fn), retType, constants, TLI, TA,
-            /*should return*/ false, /*dretPtr*/ false, /*topLevel*/ false,
-            tapeType, type_args, volatile_args, &aug, AtomicAdd,
-            /*fwdMode*/ false, PostOpt);
+            /*should return*/ false, /*dretPtr*/ false, mode, tapeType,
+            type_args, volatile_args, &aug, AtomicAdd, PostOpt);
     }
     }
 

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -635,9 +635,7 @@ void calculateUnusedValuesInFunction(
       func, unnecessaryValues, unnecessaryInstructions, returnValue,
       [&](const Value *val) {
         bool ivn = is_value_needed_in_reverse<ValueType::Primal>(
-            TR, gutils, val,
-            /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-            PrimalSeen, oldUnreachable);
+            TR, gutils, val, mode, PrimalSeen, oldUnreachable);
         return ivn;
       },
       [&](const Instruction *inst) {
@@ -810,9 +808,7 @@ void calculateUnusedValuesInFunction(
             mode == DerivativeMode::ReverseModeGradient)
           return UseReq::Recur;
         bool ivn = is_value_needed_in_reverse<ValueType::Primal>(
-            TR, gutils, inst,
-            /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-            PrimalSeen, oldUnreachable);
+            TR, gutils, inst, mode, PrimalSeen, oldUnreachable);
         if (ivn) {
           return UseReq::Need;
         }
@@ -1158,7 +1154,8 @@ bool legalCombinedForwardReverse(
       return;
     }
     if (is_value_needed_in_reverse<ValueType::Primal>(
-            TR, gutils, I, /*topLevel*/ true, oldUnreachable)) {
+            TR, gutils, I, DerivativeMode::ReverseModeCombined,
+            oldUnreachable)) {
       legal = false;
       if (EnzymePrintPerf) {
         if (called)

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -800,7 +800,8 @@ void calculateUnusedValuesInFunction(
           }
         }
         if ((mode == DerivativeMode::ReverseModePrimal ||
-             mode == DerivativeMode::ReverseModeCombined) &&
+             mode == DerivativeMode::ReverseModeCombined ||
+             mode == DerivativeMode::ForwardMode) &&
             inst->mayWriteToMemory() && !isLibMFn) {
           return UseReq::Need;
         }
@@ -2767,11 +2768,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   SmallPtrSet<const Instruction *, 4> unnecessaryInstructions;
   calculateUnusedValuesInFunction(
       *gutils->oldFunc, unnecessaryValues, unnecessaryInstructions, returnValue,
-      (mode == DerivativeMode::ReverseModeCombined ||
-       mode == DerivativeMode::ForwardMode)
-          ? DerivativeMode::ReverseModeCombined
-          : DerivativeMode::ReverseModeGradient,
-      TR, gutils, TLI, constant_args, guaranteedUnreachable);
+      mode, TR, gutils, TLI, constant_args, guaranteedUnreachable);
 
   SmallPtrSet<const Instruction *, 4> unnecessaryStores;
   calculateUnusedStoresInFunction(*gutils->oldFunc, unnecessaryStores,

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -22,7 +22,7 @@
 // CreateAugmentedPrimal. CreatePrimalAndGradient takes a function, known
 // TypeResults of the calling context, known activity analysis of the
 // arguments. It creates a corresponding gradient
-// function, computing the primal as well.
+// function, computing the primal as well if requested.
 // CreateAugmentedPrimal takes similar arguments and creates an augmented
 // primal pass.
 //
@@ -1460,8 +1460,7 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   std::map<AugmentedStruct, int> returnMapping;
 
   GradientUtils *gutils = GradientUtils::CreateFromClone(
-      *this, todiff, TLI, TA, DerivativeMode::ReverseModePrimal, retType,
-      constant_args,
+      *this, todiff, TLI, TA, retType, constant_args,
       /*returnUsed*/ returnUsed, returnMapping);
   if (omp)
     gutils->setupOMPFor();
@@ -2510,6 +2509,10 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
     const std::map<Argument *, bool> _uncacheable_args,
     const AugmentedReturn *augmenteddata, bool AtomicAdd, bool PostOpt,
     bool omp) {
+
+  assert(mode == DerivativeMode::ReverseModeCombined ||
+         mode == DerivativeMode::ReverseModeGradient ||
+         mode == DerivativeMode::ForwardMode);
 
   FnTypeInfo oldTypeInfo = oldTypeInfo_;
   for (auto &pair : oldTypeInfo.KnownValues) {

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -1462,7 +1462,8 @@ const AugmentedReturn &EnzymeLogic::CreateAugmentedPrimal(
   std::map<AugmentedStruct, int> returnMapping;
 
   GradientUtils *gutils = GradientUtils::CreateFromClone(
-      *this, todiff, TLI, TA, retType, constant_args,
+      *this, todiff, TLI, TA, DerivativeMode::ReverseModePrimal, retType,
+      constant_args,
       /*returnUsed*/ returnUsed, returnMapping);
   if (omp)
     gutils->setupOMPFor();

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2680,11 +2680,8 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                             : retType == DIFFE_TYPE::OUT_DIFF;
 
   DiffeGradientUtils *gutils = DiffeGradientUtils::CreateFromClone(
-      *this,
-      mode == DerivativeMode::ReverseModeCombined ||
-          mode == DerivativeMode::ForwardMode,
-      todiff, TLI, TA, retType, diffeReturnArg, constant_args, retVal,
-      additionalArg);
+      *this, mode, todiff, TLI, TA, retType, diffeReturnArg, constant_args,
+      retVal, additionalArg);
 
   if (omp)
     gutils->setupOMPFor();

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2538,12 +2538,11 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   if (retType != DIFFE_TYPE::CONSTANT)
     assert(!todiff->getReturnType()->isVoidTy());
 
-  ReverseCacheKey tup = std::make_tuple(
-      todiff, retType, constant_args,
-      std::map<Argument *, bool>(_uncacheable_args.begin(),
-                                 _uncacheable_args.end()),
-      returnUsed, dretPtr, mode == DerivativeMode::ReverseModeCombined,
-      additionalArg, oldTypeInfo);
+  ReverseCacheKey tup =
+      std::make_tuple(todiff, retType, constant_args,
+                      std::map<Argument *, bool>(_uncacheable_args.begin(),
+                                                 _uncacheable_args.end()),
+                      returnUsed, dretPtr, mode, additionalArg, oldTypeInfo);
   if (ReverseCachedFunctions.find(tup) != ReverseCachedFunctions.end()) {
     return ReverseCachedFunctions.find(tup)->second;
   }

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -161,7 +161,7 @@ public:
       std::tuple<llvm::Function *, DIFFE_TYPE /*retType*/,
                  std::vector<DIFFE_TYPE> /*constant_args*/,
                  std::map<llvm::Argument *, bool> /*uncacheable_args*/,
-                 bool /*retval*/, bool /*dretPtr*/, bool /*topLevel*/,
+                 bool /*retval*/, bool /*dretPtr*/, DerivativeMode,
                  llvm::Type *, const FnTypeInfo>;
   std::map<ReverseCacheKey, llvm::Function *> ReverseCachedFunctions;
 

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -183,11 +183,11 @@ public:
       llvm::Function *todiff, DIFFE_TYPE retType,
       const std::vector<DIFFE_TYPE> &constant_args,
       llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA, bool returnValue,
-      bool dretUsed, bool topLevel, llvm::Type *additionalArg,
+      bool dretUsed, DerivativeMode mode, llvm::Type *additionalArg,
       const FnTypeInfo &typeInfo,
       const std::map<llvm::Argument *, bool> _uncacheable_args,
-      const AugmentedReturn *augmented, bool AtomicAdd, bool fwdMode,
-      bool PostOpt = false, bool omp = false);
+      const AugmentedReturn *augmented, bool AtomicAdd, bool PostOpt = false,
+      bool omp = false);
 
   void clear();
 };

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -1378,13 +1378,13 @@ Function *PreProcessCache::preprocessForClone(Function *F, bool topLevel) {
 }
 
 Function *PreProcessCache::CloneFunctionWithReturns(
-    bool topLevel, Function *&F, ValueToValueMapTy &ptrInputs,
+    DerivativeMode mode, Function *&F, ValueToValueMapTy &ptrInputs,
     const std::vector<DIFFE_TYPE> &constant_args,
     SmallPtrSetImpl<Value *> &constants, SmallPtrSetImpl<Value *> &nonconstant,
     SmallPtrSetImpl<Value *> &returnvals, ReturnType returnValue, Twine name,
     ValueToValueMapTy *VMapO, bool diffeReturnArg, llvm::Type *additionalArg) {
   assert(!F->empty());
-  F = preprocessForClone(F, topLevel);
+  F = preprocessForClone(F, mode == DerivativeMode::ReverseModeCombined);
   std::vector<Type *> RetTypes;
   if (returnValue == ReturnType::ArgsWithReturn ||
       returnValue == ReturnType::ArgsWithTwoReturns ||

--- a/enzyme/Enzyme/FunctionUtils.cpp
+++ b/enzyme/Enzyme/FunctionUtils.cpp
@@ -265,7 +265,8 @@ static inline bool OnlyUsedInOMP(AllocaInst *AI) {
 /// pass. Specifically if we're not topLevel all allocations must be upgraded
 /// Even if topLevel any allocations that aren't in the entry block (and
 /// therefore may not be reachable in the reverse pass) must be upgraded.
-static inline void UpgradeAllocasToMallocs(Function *NewF, bool topLevel) {
+static inline void UpgradeAllocasToMallocs(Function *NewF,
+                                           DerivativeMode mode) {
   std::vector<AllocaInst *> ToConvert;
 
   for (auto &BB : *NewF) {
@@ -275,7 +276,7 @@ static inline void UpgradeAllocasToMallocs(Function *NewF, bool topLevel) {
         // TODO use is_value_needed_in_reverse (requiring GradientUtils)
         if (OnlyUsedInOMP(AI))
           continue;
-        if (!UsableEverywhere || !topLevel) {
+        if (!UsableEverywhere || mode != DerivativeMode::ReverseModeCombined) {
           ToConvert.push_back(AI);
         }
       }
@@ -730,12 +731,15 @@ PreProcessCache::getAAResultsFromFunction(llvm::Function *NewF) {
   return FAM.getResult<AAManager>(*NewF);
 }
 
-Function *PreProcessCache::preprocessForClone(Function *F, bool topLevel) {
+Function *PreProcessCache::preprocessForClone(Function *F,
+                                              DerivativeMode mode) {
 
   // If we've already processed this, return the previous version
   // and derive aliasing information
-  if (cache.find(std::make_pair(F, topLevel)) != cache.end()) {
-    Function *NewF = cache[std::make_pair(F, topLevel)];
+  if (cache.find(std::make_pair(
+          F, mode == DerivativeMode::ReverseModeCombined)) != cache.end()) {
+    Function *NewF =
+        cache[std::make_pair(F, mode == DerivativeMode::ReverseModeCombined)];
     return NewF;
   }
 
@@ -1191,7 +1195,7 @@ Function *PreProcessCache::preprocessForClone(Function *F, bool topLevel) {
 
   // For subfunction calls upgrade stack allocations to mallocs
   // to ensure availability in the reverse pass
-  UpgradeAllocasToMallocs(NewF, topLevel);
+  UpgradeAllocasToMallocs(NewF, mode);
 
   CanonicalizeLoops(NewF, FAM);
 
@@ -1373,7 +1377,7 @@ Function *PreProcessCache::preprocessForClone(Function *F, bool topLevel) {
     llvm::errs() << *NewF << "\n";
     report_fatal_error("function failed verification (1)");
   }
-  cache[std::make_pair(F, topLevel)] = NewF;
+  cache[std::make_pair(F, mode == DerivativeMode::ReverseModeCombined)] = NewF;
   return NewF;
 }
 
@@ -1384,7 +1388,7 @@ Function *PreProcessCache::CloneFunctionWithReturns(
     SmallPtrSetImpl<Value *> &returnvals, ReturnType returnValue, Twine name,
     ValueToValueMapTy *VMapO, bool diffeReturnArg, llvm::Type *additionalArg) {
   assert(!F->empty());
-  F = preprocessForClone(F, mode == DerivativeMode::ReverseModeCombined);
+  F = preprocessForClone(F, mode);
   std::vector<Type *> RetTypes;
   if (returnValue == ReturnType::ArgsWithReturn ||
       returnValue == ReturnType::ArgsWithTwoReturns ||

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -59,14 +59,16 @@ public:
 
   llvm::AAResults &getAAResultsFromFunction(llvm::Function *NewF);
 
-  llvm::Function *CloneFunctionWithReturns(
-      bool topLevel, llvm::Function *&F, llvm::ValueToValueMapTy &ptrInputs,
-      const std::vector<DIFFE_TYPE> &constant_args,
-      llvm::SmallPtrSetImpl<llvm::Value *> &constants,
-      llvm::SmallPtrSetImpl<llvm::Value *> &nonconstant,
-      llvm::SmallPtrSetImpl<llvm::Value *> &returnvals, ReturnType returnValue,
-      llvm::Twine name, llvm::ValueToValueMapTy *VMapO, bool diffeReturnArg,
-      llvm::Type *additionalArg = nullptr);
+  llvm::Function *
+  CloneFunctionWithReturns(DerivativeMode mode, llvm::Function *&F,
+                           llvm::ValueToValueMapTy &ptrInputs,
+                           const std::vector<DIFFE_TYPE> &constant_args,
+                           llvm::SmallPtrSetImpl<llvm::Value *> &constants,
+                           llvm::SmallPtrSetImpl<llvm::Value *> &nonconstant,
+                           llvm::SmallPtrSetImpl<llvm::Value *> &returnvals,
+                           ReturnType returnValue, llvm::Twine name,
+                           llvm::ValueToValueMapTy *VMapO, bool diffeReturnArg,
+                           llvm::Type *additionalArg = nullptr);
 
   void ReplaceReallocs(llvm::Function *NewF, bool mem2reg = false);
   void optimizeIntermediate(llvm::Function *F);

--- a/enzyme/Enzyme/FunctionUtils.h
+++ b/enzyme/Enzyme/FunctionUtils.h
@@ -55,7 +55,7 @@ public:
   std::map<std::pair<llvm::Function *, bool>, llvm::Function *> cache;
   std::map<llvm::Function *, llvm::Function *> CloneOrigin;
 
-  llvm::Function *preprocessForClone(llvm::Function *F, bool topLevel);
+  llvm::Function *preprocessForClone(llvm::Function *F, DerivativeMode mode);
 
   llvm::AAResults &getAAResultsFromFunction(llvm::Function *NewF);
 

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2037,7 +2037,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
 
 GradientUtils *GradientUtils::CreateFromClone(
     EnzymeLogic &Logic, Function *todiff, TargetLibraryInfo &TLI,
-    TypeAnalysis &TA, DerivativeMode mode, DIFFE_TYPE retType,
+    TypeAnalysis &TA, DIFFE_TYPE retType,
     const std::vector<DIFFE_TYPE> &constant_args, bool returnUsed,
     std::map<AugmentedStruct, int> &returnMapping) {
   assert(!todiff->empty());
@@ -2084,8 +2084,8 @@ GradientUtils *GradientUtils::CreateFromClone(
   SmallPtrSet<Value *, 4> nonconstant_values;
 
   auto newFunc = Logic.PPC.CloneFunctionWithReturns(
-      mode, todiff, invertedPointers, constant_args, constant_values,
-      nonconstant_values, returnvals,
+      DerivativeMode::ReverseModePrimal, todiff, invertedPointers,
+      constant_args, constant_values, nonconstant_values, returnvals,
       /*returnValue*/ returnValue, "fakeaugmented_" + todiff->getName(),
       &originalToNew,
       /*diffeReturnArg*/ false, /*additionalArg*/ nullptr);
@@ -2104,6 +2104,9 @@ DiffeGradientUtils *DiffeGradientUtils::CreateFromClone(
     bool diffeReturnArg, const std::vector<DIFFE_TYPE> &constant_args,
     ReturnType returnValue, Type *additionalArg) {
   assert(!todiff->empty());
+  assert(mode == DerivativeMode::ReverseModeGradient ||
+         mode == DerivativeMode::ReverseModeCombined ||
+         mode == DerivativeMode::ForwardMode);
   ValueToValueMapTy invertedPointers;
   SmallPtrSet<Instruction *, 4> constants;
   SmallPtrSet<Instruction *, 20> nonconstant;

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2411,10 +2411,11 @@ Value *GradientUtils::invertPointerM(Value *oval, IRBuilder<> &BuilderM) {
         /*PostOpt*/ false);
     Constant *newf = Logic.CreatePrimalAndGradient(
         fn, retType, /*constant_args*/ types, TLI, TA,
-        /*returnValue*/ false, /*dretPtr*/ false, /*topLevel*/ false,
+        /*returnValue*/ false, /*dretPtr*/ false,
+        DerivativeMode::ReverseModeGradient,
         /*additionalArg*/ Type::getInt8PtrTy(fn->getContext()), type_args,
         uncacheable_args,
-        /*map*/ &augdata, AtomicAdd, /*fwdMode*/ false);
+        /*map*/ &augdata, AtomicAdd);
     if (!newf)
       newf = UndefValue::get(fn->getType());
     auto cdata = ConstantStruct::get(

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2037,7 +2037,7 @@ bool GradientUtils::shouldRecompute(const Value *val,
 
 GradientUtils *GradientUtils::CreateFromClone(
     EnzymeLogic &Logic, Function *todiff, TargetLibraryInfo &TLI,
-    TypeAnalysis &TA, DIFFE_TYPE retType,
+    TypeAnalysis &TA, DerivativeMode mode, DIFFE_TYPE retType,
     const std::vector<DIFFE_TYPE> &constant_args, bool returnUsed,
     std::map<AugmentedStruct, int> &returnMapping) {
   assert(!todiff->empty());
@@ -2084,8 +2084,8 @@ GradientUtils *GradientUtils::CreateFromClone(
   SmallPtrSet<Value *, 4> nonconstant_values;
 
   auto newFunc = Logic.PPC.CloneFunctionWithReturns(
-      /*topLevel*/ false, todiff, invertedPointers, constant_args,
-      constant_values, nonconstant_values, returnvals,
+      mode, todiff, invertedPointers, constant_args, constant_values,
+      nonconstant_values, returnvals,
       /*returnValue*/ returnValue, "fakeaugmented_" + todiff->getName(),
       &originalToNew,
       /*diffeReturnArg*/ false, /*additionalArg*/ nullptr);
@@ -2114,9 +2114,9 @@ DiffeGradientUtils *DiffeGradientUtils::CreateFromClone(
   SmallPtrSet<Value *, 4> nonconstant_values;
 
   auto newFunc = Logic.PPC.CloneFunctionWithReturns(
-      mode == DerivativeMode::ReverseModeCombined, todiff, invertedPointers,
-      constant_args, constant_values, nonconstant_values, returnvals,
-      returnValue, "diffe" + todiff->getName(), &originalToNew,
+      mode, todiff, invertedPointers, constant_args, constant_values,
+      nonconstant_values, returnvals, returnValue, "diffe" + todiff->getName(),
+      &originalToNew,
       /*diffeReturnArg*/ diffeReturnArg, additionalArg);
   auto res = new DiffeGradientUtils(
       Logic, newFunc, todiff, TLI, TA, invertedPointers, constant_values,

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -4345,14 +4345,10 @@ void GradientUtils::computeMinCache(
 
         if (!legalRecompute(&I, Available2, nullptr)) {
           if (is_value_needed_in_reverse<ValueType::Primal>(
-                  TR, this, &I,
-                  /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-                  FullSeen, guaranteedUnreachable)) {
+                  TR, this, &I, mode, FullSeen, guaranteedUnreachable)) {
             bool oneneed = is_value_needed_in_reverse<ValueType::Primal,
                                                       /*OneLevel*/ true>(
-                TR, this, &I,
-                /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-                OneLevelSeen, guaranteedUnreachable);
+                TR, this, &I, mode, OneLevelSeen, guaranteedUnreachable);
             if (oneneed)
               knownRecomputeHeuristic[&I] = false;
             else
@@ -4375,9 +4371,7 @@ void GradientUtils::computeMinCache(
       if (Intermediates.count(V))
         continue;
       if (!is_value_needed_in_reverse<ValueType::Primal>(
-              TR, this, V,
-              /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-              FullSeen, guaranteedUnreachable)) {
+              TR, this, V, mode, FullSeen, guaranteedUnreachable)) {
         continue;
       }
       if (!Recomputes.count(V)) {
@@ -4398,9 +4392,7 @@ void GradientUtils::computeMinCache(
       }
       Intermediates.insert(V);
       if (is_value_needed_in_reverse<ValueType::Primal, /*OneLevel*/ true>(
-              TR, this, V,
-              /*topLevel*/ mode == DerivativeMode::ReverseModeCombined,
-              OneLevelSeen, guaranteedUnreachable)) {
+              TR, this, V, mode, OneLevelSeen, guaranteedUnreachable)) {
         Required.insert(V);
       } else {
         for (auto V2 : V->users()) {

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -1219,7 +1219,7 @@ class DiffeGradientUtils : public GradientUtils {
 public:
   ValueToValueMapTy differentials;
   static DiffeGradientUtils *
-  CreateFromClone(EnzymeLogic &Logic, bool topLevel, Function *todiff,
+  CreateFromClone(EnzymeLogic &Logic, DerivativeMode mode, Function *todiff,
                   TargetLibraryInfo &TLI, TypeAnalysis &TA, DIFFE_TYPE retType,
                   bool diffeReturnArg,
                   const std::vector<DIFFE_TYPE> &constant_args,

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -763,7 +763,7 @@ public:
 public:
   static GradientUtils *
   CreateFromClone(EnzymeLogic &Logic, Function *todiff, TargetLibraryInfo &TLI,
-                  TypeAnalysis &TA, DerivativeMode mode, DIFFE_TYPE retType,
+                  TypeAnalysis &TA, DIFFE_TYPE retType,
                   const std::vector<DIFFE_TYPE> &constant_args, bool returnUsed,
                   std::map<AugmentedStruct, int> &returnMapping);
 

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -71,13 +71,6 @@
 
 using namespace llvm;
 
-enum class DerivativeMode {
-  ForwardMode,
-  ReverseModePrimal,
-  ReverseModeGradient,
-  ReverseModeCombined
-};
-
 #include "llvm-c/Core.h"
 
 extern std::map<std::string, std::function<llvm::Value *(
@@ -86,20 +79,6 @@ extern std::map<std::string, std::function<llvm::Value *(
 
 extern "C" {
 extern llvm::cl::opt<bool> EnzymeInactiveDynamic;
-}
-
-static inline std::string to_string(DerivativeMode mode) {
-  switch (mode) {
-  case DerivativeMode::ForwardMode:
-    return "ForwardMode";
-  case DerivativeMode::ReverseModePrimal:
-    return "ReverseModePrimal";
-  case DerivativeMode::ReverseModeGradient:
-    return "ReverseModeGradient";
-  case DerivativeMode::ReverseModeCombined:
-    return "ReverseModeCombined";
-  }
-  llvm_unreachable("illegal derivative mode");
 }
 
 enum class AugmentedStruct;

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -763,7 +763,7 @@ public:
 public:
   static GradientUtils *
   CreateFromClone(EnzymeLogic &Logic, Function *todiff, TargetLibraryInfo &TLI,
-                  TypeAnalysis &TA, DIFFE_TYPE retType,
+                  TypeAnalysis &TA, DerivativeMode mode, DIFFE_TYPE retType,
                   const std::vector<DIFFE_TYPE> &constant_args, bool returnUsed,
                   std::map<AugmentedStruct, int> &returnMapping);
 

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -232,6 +232,27 @@ enum class DIFFE_TYPE {
                  // don't need the forward
 };
 
+enum class DerivativeMode {
+  ForwardMode = 0,
+  ReverseModePrimal = 1,
+  ReverseModeGradient = 2,
+  ReverseModeCombined = 3,
+};
+
+static inline std::string to_string(DerivativeMode mode) {
+  switch (mode) {
+  case DerivativeMode::ForwardMode:
+    return "ForwardMode";
+  case DerivativeMode::ReverseModePrimal:
+    return "ReverseModePrimal";
+  case DerivativeMode::ReverseModeGradient:
+    return "ReverseModeGradient";
+  case DerivativeMode::ReverseModeCombined:
+    return "ReverseModeCombined";
+  }
+  llvm_unreachable("illegal derivative mode");
+}
+
 /// Convert DIFFE_TYPE to a string
 static inline std::string to_string(DIFFE_TYPE t) {
   switch (t) {


### PR DESCRIPTION
I've merged the common boolean flags `fwdMode` and `topLevel` into `DerivativeMode mode` since they were often used in combination to convey the current mode throughout Enzyme.
Combining these flags will clean up some ambiguity. 