### PR TITLE
support m1

### DIFF
--- a/.packaging/build_tarballs.jl
+++ b/.packaging/build_tarballs.jl
@@ -38,7 +38,7 @@ ninja -C build -j ${nproc} install
 function configure(julia_version, llvm_version)
     # These are the platforms we will build for by default, unless further
     # platforms are passed in on the command line
-    platforms = expand_cxxstring_abis(supported_platforms())
+    platforms = expand_cxxstring_abis(supported_platforms(; experimental=julia_version>=v"1.7"))
 
     foreach(platforms) do p
         BinaryPlatforms.add_tag!(p.tags, "julia_version", string(julia_version))


### PR DESCRIPTION
in trying to use some of the sciml stack (on m1), i ran into the following

```julia 
```julia 
(@v1.7) pkg> add Enzyme
    Updating registry at `~/.julia/registries/General.toml`
    Updating registry at `~/.julia/registries/JuliaSimRegistry.toml`
   Resolving package versions...
    Updating `~/.julia/environments/v1.7/Project.toml`
  [7da242da] + Enzyme v0.7.0
    Updating `~/.julia/environments/v1.7/Manifest.toml`
  [7da242da] + Enzyme v0.7.0
  [61eb1bfa] + GPUCompiler v0.12.9
  [929cbde3] + LLVM v4.2.0
  [7cc45869] + Enzyme_jll v0.0.16+0
  [dad2f222] + LLVMExtra_jll v0.0.8+0

julia> using Enzyme
ERROR: InitError: UndefVarError: libEnzyme not defined
Stacktrace:
 [1] EnzymeRegisterAllocationHandler(name::String, ahandle::Ptr{Nothing}, fhandle::Ptr{Nothing})
   @ Enzyme.API ~/.julia/packages/Enzyme/afnXq/src/api.jl:145
 [2] __init__()
   @ Enzyme.Compiler ~/.julia/packages/Enzyme/afnXq/src/compiler.jl:822
 [3] _include_from_serialized(path::String, depmods::Vector{Any})
   @ Base ./loading.jl:768
 [4] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String)
   @ Base ./loading.jl:854
 [5] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1097
 [6] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:1013
 [7] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:997
during initialization of module Compiler
```

mose said this should fix it. although I have pretty little experience with BB, so I don't know how to check that it will work