### PR TITLE
Fix cbrt test on macOS

### DIFF
--- a/enzyme/test/Enzyme/ReverseMode/cbrt.ll
+++ b/enzyme/test/Enzyme/ReverseMode/cbrt.ll
@@ -21,9 +21,9 @@ declare double @__enzyme_autodiff(double (double)*, ...)
 ; CHECK: define internal { double } @diffetester(double %x, double %differeturn) {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   %0 = call fast double @cbrt(double %x)
-; CHECK-NEXT:   %1 = fmul fast double 3.000000e+00, %x
-; CHECK-NEXT:   %2 = fmul fast double %differeturn, %0
-; CHECK-NEXT:   %3 = fdiv fast double %2, %1
+; CHECK-DAG:    [[REG1:%[0-9]+]] = fmul fast double 3.000000e+00, %x
+; CHECK-DAG:    [[REG2:%[0-9]+]] = fmul fast double %differeturn, %0
+; CHECK-NEXT:   %3 = fdiv fast double [[REG2]], [[REG1]]
 ; CHECK-NEXT:   %4 = insertvalue { double } undef, double %3, 0
 ; CHECK-NEXT:   ret { double } %4
 ; CHECK-NEXT: }


### PR DESCRIPTION
The reverse mode cbrt.ll test is currently failing on macOS due to different instruction ordering.