### PR TITLE
Simplify argument handling and add enzyme_nofree option

### DIFF
--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -885,6 +885,9 @@ public:
     case DerivativeMode::ReverseModeCombined: {
       return;
     }
+    case DerivativeMode::ForwardModeVector:
+      assert("vector forward not yet implemented");
+    case DerivativeMode::ForwardModeSplit:
     case DerivativeMode::ForwardMode: {
       break;
     }
@@ -1482,6 +1485,9 @@ public:
     // TODO type analysis handle structs
 
     switch (Mode) {
+    case DerivativeMode::ForwardModeVector:
+      assert("vector forward not yet implemented");
+    case DerivativeMode::ForwardModeSplit:
     case DerivativeMode::ForwardMode: {
       IRBuilder<> Builder2(&IVI);
       getForwardBuilder(Builder2);
@@ -1609,7 +1615,10 @@ public:
     case DerivativeMode::ReverseModeCombined:
       createBinaryOperatorAdjoint(BO);
       break;
+    case DerivativeMode::ForwardModeVector:
+      assert("vector forward not yet implemented");
     case DerivativeMode::ForwardMode:
+    case DerivativeMode::ForwardModeSplit:
       createBinaryOperatorDual(BO);
       break;
     case DerivativeMode::ReverseModePrimal:
@@ -3903,12 +3912,12 @@ public:
                               .shadowReturnUsed = false,
                               .mode = DerivativeMode::ReverseModeGradient,
                               .freeMemory = true,
+                              .AtomicAdd = true,
                               .additionalType =
                                   tape ? PointerType::getUnqual(tape->getType())
                                        : nullptr,
                               .typeInfo = nextTypeInfo},
             gutils->TLI, TR.analyzer.interprocedural, subdata,
-            /*AtomicAdd*/ true,
             /*postopt*/ false, /*omp*/ true);
 
         if (subdata->returns.find(AugmentedStruct::Tape) !=
@@ -8542,9 +8551,10 @@ public:
                             .shadowReturnUsed = subdretptr,
                             .mode = subMode,
                             .freeMemory = true,
+                            .AtomicAdd = gutils->AtomicAdd,
                             .additionalType = tape ? tape->getType() : nullptr,
                             .typeInfo = nextTypeInfo},
-          gutils->TLI, TR.analyzer.interprocedural, subdata, gutils->AtomicAdd);
+          gutils->TLI, TR.analyzer.interprocedural, subdata);
       if (!newcalled)
         return;
     } else {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3895,21 +3895,20 @@ public:
         }
 
         newcalled = gutils->Logic.CreatePrimalAndGradient(
-          (ReverseCacheKey){
-            .todiff=cast<Function>(called),
-            .retType=subretType,
-            .constant_args=argsInverted,
-            .uncacheable_args=uncacheable_args,
-            .returnUsed=false,
-            .shadowReturnUsed=false,
-            .mode=DerivativeMode::ReverseModeGradient,
-            .freeMemory=true,
-            .additionalType=tape ? PointerType::getUnqual(tape->getType()) : nullptr,
-            .typeInfo=nextTypeInfo
-          },
-            gutils->TLI,
-            TR.analyzer.interprocedural, 
-            subdata, /*AtomicAdd*/ true,
+            (ReverseCacheKey){.todiff = cast<Function>(called),
+                              .retType = subretType,
+                              .constant_args = argsInverted,
+                              .uncacheable_args = uncacheable_args,
+                              .returnUsed = false,
+                              .shadowReturnUsed = false,
+                              .mode = DerivativeMode::ReverseModeGradient,
+                              .freeMemory = true,
+                              .additionalType =
+                                  tape ? PointerType::getUnqual(tape->getType())
+                                       : nullptr,
+                              .typeInfo = nextTypeInfo},
+            gutils->TLI, TR.analyzer.interprocedural, subdata,
+            /*AtomicAdd*/ true,
             /*postopt*/ false, /*omp*/ true);
 
         if (subdata->returns.find(AugmentedStruct::Tape) !=
@@ -8535,22 +8534,17 @@ public:
                                  : DerivativeMode::ReverseModeGradient;
     if (called) {
       newcalled = gutils->Logic.CreatePrimalAndGradient(
-          (ReverseCacheKey){
-            .todiff=cast<Function>(called),
-            .retType=subretType,
-            .constant_args=argsInverted,
-            .uncacheable_args=uncacheable_args,
-            .returnUsed=retUsed,
-            .shadowReturnUsed=subdretptr,
-            .mode=subMode,
-            .freeMemory=true,
-            .additionalType=tape ? tape->getType() : nullptr,
-            .typeInfo=nextTypeInfo
-          },
-          gutils->TLI,
-          TR.analyzer.interprocedural, 
-          subdata,
-          gutils->AtomicAdd);
+          (ReverseCacheKey){.todiff = cast<Function>(called),
+                            .retType = subretType,
+                            .constant_args = argsInverted,
+                            .uncacheable_args = uncacheable_args,
+                            .returnUsed = retUsed,
+                            .shadowReturnUsed = subdretptr,
+                            .mode = subMode,
+                            .freeMemory = true,
+                            .additionalType = tape ? tape->getType() : nullptr,
+                            .typeInfo = nextTypeInfo},
+          gutils->TLI, TR.analyzer.interprocedural, subdata, gutils->AtomicAdd);
       if (!newcalled)
         return;
     } else {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -3895,11 +3895,21 @@ public:
         }
 
         newcalled = gutils->Logic.CreatePrimalAndGradient(
-            cast<Function>(called), subretType, argsInverted, gutils->TLI,
-            TR.analyzer.interprocedural, /*returnValue*/ false,
-            /*subdretptr*/ false, DerivativeMode::ReverseModeGradient,
-            tape ? PointerType::getUnqual(tape->getType()) : nullptr,
-            nextTypeInfo, uncacheable_args, subdata, /*AtomicAdd*/ true,
+          (ReverseCacheKey){
+            .todiff=cast<Function>(called),
+            .retType=subretType,
+            .constant_args=argsInverted,
+            .uncacheable_args=uncacheable_args,
+            .returnUsed=false,
+            .shadowReturnUsed=false,
+            .mode=DerivativeMode::ReverseModeGradient,
+            .freeMemory=true,
+            .additionalType=tape ? PointerType::getUnqual(tape->getType()) : nullptr,
+            .typeInfo=nextTypeInfo
+          },
+            gutils->TLI,
+            TR.analyzer.interprocedural, 
+            subdata, /*AtomicAdd*/ true,
             /*postopt*/ false, /*omp*/ true);
 
         if (subdata->returns.find(AugmentedStruct::Tape) !=
@@ -8525,11 +8535,22 @@ public:
                                  : DerivativeMode::ReverseModeGradient;
     if (called) {
       newcalled = gutils->Logic.CreatePrimalAndGradient(
-          cast<Function>(called), subretType, argsInverted, gutils->TLI,
-          TR.analyzer.interprocedural, /*returnValue*/ retUsed,
-          /*subdretptr*/ subdretptr, subMode, tape ? tape->getType() : nullptr,
-          nextTypeInfo, uncacheable_args, subdata,
-          gutils->AtomicAdd); //, LI, DT);
+          (ReverseCacheKey){
+            .todiff=cast<Function>(called),
+            .retType=subretType,
+            .constant_args=argsInverted,
+            .uncacheable_args=uncacheable_args,
+            .returnUsed=retUsed,
+            .shadowReturnUsed=subdretptr,
+            .mode=subMode,
+            .freeMemory=true,
+            .additionalType=tape ? tape->getType() : nullptr,
+            .typeInfo=nextTypeInfo
+          },
+          gutils->TLI,
+          TR.analyzer.interprocedural, 
+          subdata,
+          gutils->AtomicAdd);
       if (!newcalled)
         return;
     } else {

--- a/enzyme/Enzyme/AdjointGenerator.h
+++ b/enzyme/Enzyme/AdjointGenerator.h
@@ -1569,17 +1569,20 @@ public:
   }
 
   Value *diffe(Value *val, IRBuilder<> &Builder) {
-    assert(Mode == DerivativeMode::ReverseModeGradient ||
-           Mode == DerivativeMode::ReverseModeCombined ||
-           Mode == DerivativeMode::ForwardMode);
+    assert(Mode != DerivativeMode::ReverseModePrimal);
     return ((DiffeGradientUtils *)gutils)->diffe(val, Builder);
   }
 
   void setDiffe(Value *val, Value *dif, IRBuilder<> &Builder) {
-    assert(Mode == DerivativeMode::ReverseModeGradient ||
-           Mode == DerivativeMode::ReverseModeCombined ||
-           Mode == DerivativeMode::ForwardMode);
+    assert(Mode != DerivativeMode::ReverseModePrimal);
     ((DiffeGradientUtils *)gutils)->setDiffe(val, dif, Builder);
+  }
+
+  bool shouldFree() {
+    assert(Mode == DerivativeMode::ReverseModeCombined ||
+           Mode == DerivativeMode::ReverseModeGradient ||
+           Mode == DerivativeMode::ForwardModeSplit);
+    return ((DiffeGradientUtils *)gutils)->FreeMemory;
   }
 
   std::vector<SelectInst *> addToDiffe(Value *val, Value *dif,
@@ -4134,7 +4137,7 @@ public:
                            Builder2, TR.addingType(size, OutTypes[i]));
         }
 
-        if (tape) {
+        if (tape && shouldFree()) {
           for (auto idx : subdata->tapeIndiciesToFree) {
             auto ci = cast<CallInst>(CallInst::CreateFree(
                 Builder2.CreatePointerCast(
@@ -4516,16 +4519,19 @@ public:
                                         firstallocation, shadow, len_arg,
                                         Builder2);
 
-            auto ci = cast<CallInst>(CallInst::CreateFree(
-                firstallocation, Builder2.GetInsertBlock()));
+            if (shouldFree()) {
+              auto ci = cast<CallInst>(CallInst::CreateFree(
+                  firstallocation, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-            ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                    Attribute::NonNull);
+              ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                      Attribute::NonNull);
 #else
-            ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+              ci->addAttribute(AttributeList::FirstArgIndex,
+                               Attribute::NonNull);
 #endif
-            if (ci->getParent() == nullptr) {
-              Builder2.Insert(ci);
+              if (ci->getParent() == nullptr) {
+                Builder2.Insert(ci);
+              }
             }
           } else
             assert(0 && "illegal mpi");
@@ -4583,17 +4589,19 @@ public:
         Builder2.SetInsertPoint(nonnullBlock);
 
         Value *cache = Builder2.CreateLoad(d_reqp);
-        CallInst *freecall = cast<CallInst>(
-            CallInst::CreateFree(d_reqp, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          CallInst *freecall = cast<CallInst>(
+              CallInst::CreateFree(d_reqp, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        freecall->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                      Attribute::NonNull);
+          freecall->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                        Attribute::NonNull);
 #else
-        freecall->addAttribute(AttributeList::FirstArgIndex,
-                               Attribute::NonNull);
+          freecall->addAttribute(AttributeList::FirstArgIndex,
+                                 Attribute::NonNull);
 #endif
-        if (freecall->getParent() == nullptr) {
-          Builder2.Insert(freecall);
+          if (freecall->getParent() == nullptr) {
+            Builder2.Insert(freecall);
+          }
         }
 
         Function *dwait = getOrInsertDifferentialMPI_Wait(
@@ -4688,17 +4696,19 @@ public:
         Builder2.SetInsertPoint(nonnullBlock);
 
         Value *cache = Builder2.CreateLoad(d_reqp);
-        CallInst *freecall = cast<CallInst>(
-            CallInst::CreateFree(d_reqp, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          CallInst *freecall = cast<CallInst>(
+              CallInst::CreateFree(d_reqp, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        freecall->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                      Attribute::NonNull);
+          freecall->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                        Attribute::NonNull);
 #else
-        freecall->addAttribute(AttributeList::FirstArgIndex,
-                               Attribute::NonNull);
+          freecall->addAttribute(AttributeList::FirstArgIndex,
+                                 Attribute::NonNull);
 #endif
-        if (freecall->getParent() == nullptr) {
-          Builder2.Insert(freecall);
+          if (freecall->getParent() == nullptr) {
+            Builder2.Insert(freecall);
+          }
         }
 
         Function *dwait = getOrInsertDifferentialMPI_Wait(
@@ -4802,16 +4812,18 @@ public:
         DifferentiableMemCopyFloats(call, call.getOperand(0), firstallocation,
                                     shadow, len_arg, Builder2);
 
-        auto ci = cast<CallInst>(
-            CallInst::CreateFree(firstallocation, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          auto ci = cast<CallInst>(
+              CallInst::CreateFree(firstallocation, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                Attribute::NonNull);
+          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                  Attribute::NonNull);
 #else
-        ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-        if (ci->getParent() == nullptr) {
-          Builder2.Insert(ci);
+          if (ci->getParent() == nullptr) {
+            Builder2.Insert(ci);
+          }
         }
       }
       if (Mode == DerivativeMode::ReverseModeGradient)
@@ -5012,16 +5024,18 @@ public:
           mem->setCallingConv(memcpyF->getCallingConv());
 
           // Free up the memory of the buffer
-          auto ci = cast<CallInst>(
-              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+          if (shouldFree()) {
+            auto ci = cast<CallInst>(
+                CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                  Attribute::NonNull);
+            ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                    Attribute::NonNull);
 #else
-          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+            ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-          if (ci->getParent() == nullptr) {
-            Builder2.Insert(ci);
+            if (ci->getParent() == nullptr) {
+              Builder2.Insert(ci);
+            }
           }
         }
 
@@ -5228,16 +5242,18 @@ public:
                                     len_arg, Builder2);
 
         // Free up intermediate buffer
-        auto ci = cast<CallInst>(
-            CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          auto ci = cast<CallInst>(
+              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                Attribute::NonNull);
+          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                  Attribute::NonNull);
 #else
-        ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-        if (ci->getParent() == nullptr) {
-          Builder2.Insert(ci);
+          if (ci->getParent() == nullptr) {
+            Builder2.Insert(ci);
+          }
         }
       }
       if (Mode == DerivativeMode::ReverseModeGradient)
@@ -5373,16 +5389,18 @@ public:
                                     len_arg, Builder2);
 
         // Free up intermediate buffer
-        auto ci = cast<CallInst>(
-            CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          auto ci = cast<CallInst>(
+              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                Attribute::NonNull);
+          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                  Attribute::NonNull);
 #else
-        ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-        if (ci->getParent() == nullptr) {
-          Builder2.Insert(ci);
+          if (ci->getParent() == nullptr) {
+            Builder2.Insert(ci);
+          }
         }
       }
       if (Mode == DerivativeMode::ReverseModeGradient)
@@ -5535,16 +5553,18 @@ public:
                                     sendlen_arg, Builder2);
 
         // Free up intermediate buffer
-        auto ci = cast<CallInst>(
-            CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          auto ci = cast<CallInst>(
+              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                Attribute::NonNull);
+          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                  Attribute::NonNull);
 #else
-        ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-        if (ci->getParent() == nullptr) {
-          Builder2.Insert(ci);
+          if (ci->getParent() == nullptr) {
+            Builder2.Insert(ci);
+          }
         }
       }
       if (Mode == DerivativeMode::ReverseModeGradient)
@@ -5726,16 +5746,18 @@ public:
                                       sendlen_phi, Builder2);
 
           // Free up intermediate buffer
-          auto ci = cast<CallInst>(
-              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+          if (shouldFree()) {
+            auto ci = cast<CallInst>(
+                CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                  Attribute::NonNull);
+            ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                    Attribute::NonNull);
 #else
-          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+            ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-          if (ci->getParent() == nullptr) {
-            Builder2.Insert(ci);
+            if (ci->getParent() == nullptr) {
+              Builder2.Insert(ci);
+            }
           }
 
           Builder2.CreateBr(mergeBlock);
@@ -5881,16 +5903,18 @@ public:
                                     sendlen_arg, Builder2);
 
         // Free up intermediate buffer
-        auto ci = cast<CallInst>(
-            CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
+        if (shouldFree()) {
+          auto ci = cast<CallInst>(
+              CallInst::CreateFree(buf, Builder2.GetInsertBlock()));
 #if LLVM_VERSION_MAJOR >= 14
-        ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
-                                Attribute::NonNull);
+          ci->addAttributeAtIndex(AttributeList::FirstArgIndex,
+                                  Attribute::NonNull);
 #else
-        ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
+          ci->addAttribute(AttributeList::FirstArgIndex, Attribute::NonNull);
 #endif
-        if (ci->getParent() == nullptr) {
-          Builder2.Insert(ci);
+          if (ci->getParent() == nullptr) {
+            Builder2.Insert(ci);
+          }
         }
       }
       if (Mode == DerivativeMode::ReverseModeGradient)
@@ -6304,10 +6328,12 @@ public:
           seconddcall = Builder2.CreateCall(derivcall, args2);
         }
         setDiffe(orig, Constant::getNullValue(orig->getType()), Builder2);
-        if (xcache)
-          CallInst::CreateFree(structarg1, firstdcall->getNextNode());
-        if (ycache)
-          CallInst::CreateFree(structarg2, seconddcall->getNextNode());
+        if (shouldFree()) {
+          if (xcache)
+            CallInst::CreateFree(structarg1, firstdcall->getNextNode());
+          if (ycache)
+            CallInst::CreateFree(structarg2, seconddcall->getNextNode());
+        }
       }
 
       if (gutils->knownRecomputeHeuristic.find(orig) !=
@@ -7547,8 +7573,10 @@ public:
             Mode == DerivativeMode::ReverseModePrimal) {
           auto anti =
               gutils->createAntiMalloc(orig, getIndex(orig, CacheType::Shadow));
-          if (Mode == DerivativeMode::ReverseModeCombined ||
-              Mode == DerivativeMode::ReverseModeGradient) {
+          if ((Mode == DerivativeMode::ReverseModeCombined ||
+               Mode == DerivativeMode::ReverseModeGradient ||
+               Mode == DerivativeMode::ForwardModeSplit) &&
+              shouldFree()) {
             IRBuilder<> Builder2(call.getParent());
             getReverseBuilder(Builder2);
             Value *tofree = lookup(anti, Builder2);
@@ -7653,7 +7681,8 @@ public:
             hasPDFree) {
           Value *nop = gutils->cacheForReverse(BuilderZ, newCall,
                                                getIndex(orig, CacheType::Self));
-          if (Mode == DerivativeMode::ReverseModeGradient && hasPDFree) {
+          if (Mode == DerivativeMode::ReverseModeGradient && hasPDFree &&
+              shouldFree()) {
             IRBuilder<> Builder2(call.getParent());
             getReverseBuilder(Builder2);
             auto dbgLoc = gutils->getNewFromOriginal(orig)->getDebugLoc();
@@ -7671,7 +7700,7 @@ public:
           gutils->replaceAWithB(newCall, pn);
           gutils->erase(newCall);
         }
-      } else if (Mode == DerivativeMode::ReverseModeCombined) {
+      } else if (Mode == DerivativeMode::ReverseModeCombined && shouldFree()) {
         IRBuilder<> Builder2(call.getParent());
         getReverseBuilder(Builder2);
         auto dbgLoc = gutils->getNewFromOriginal(orig)->getDebugLoc();
@@ -7771,13 +7800,15 @@ public:
 
         if (Mode == DerivativeMode::ReverseModeCombined ||
             Mode == DerivativeMode::ReverseModeGradient) {
-          IRBuilder<> Builder2(call.getParent());
-          getReverseBuilder(Builder2);
-          Value *tofree = gutils->lookupM(val, Builder2, ValueToValueMapTy(),
-                                          /*tryLegalRecompute*/ false);
-          auto freeCall = cast<CallInst>(
-              CallInst::CreateFree(tofree, Builder2.GetInsertBlock()));
-          Builder2.GetInsertBlock()->getInstList().push_back(freeCall);
+          if (shouldFree()) {
+            IRBuilder<> Builder2(call.getParent());
+            getReverseBuilder(Builder2);
+            Value *tofree = gutils->lookupM(val, Builder2, ValueToValueMapTy(),
+                                            /*tryLegalRecompute*/ false);
+            auto freeCall = cast<CallInst>(
+                CallInst::CreateFree(tofree, Builder2.GetInsertBlock()));
+            Builder2.GetInsertBlock()->getInstList().push_back(freeCall);
+          }
         }
       }
 
@@ -7799,7 +7830,7 @@ public:
         // to find the shadow pointer will use the shadow of null rather than
         // the true shadow of this
         //}
-      } else if (Mode == DerivativeMode::ReverseModeCombined) {
+      } else if (Mode == DerivativeMode::ReverseModeCombined && shouldFree()) {
         IRBuilder<> Builder2(newCall->getNextNode());
         auto load = Builder2.CreateLoad(
             gutils->getNewFromOriginal(call.getOperand(0)), "posix_preread");
@@ -8477,7 +8508,10 @@ public:
       }
 
       if (fnandtapetype && fnandtapetype->tapeType &&
-          Mode != DerivativeMode::ReverseModePrimal) {
+          (Mode == DerivativeMode::ReverseModeCombined ||
+           Mode == DerivativeMode::ReverseModeGradient ||
+           Mode == DerivativeMode::ForwardModeSplit) &&
+          shouldFree()) {
         assert(tape);
         auto tapep = BuilderZ.CreatePointerCast(
             tape, PointerType::getUnqual(fnandtapetype->tapeType));

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -380,10 +380,11 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
           .shadowReturnUsed = dretUsed,
           .mode = (DerivativeMode)mode,
           .freeMemory = true,
+          .AtomicAdd = AtomicAdd,
           .additionalType = unwrap(additionalArg),
           .typeInfo = eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
       },
-      eunwrap(TA).TLI, eunwrap(TA), eunwrap(augmented), AtomicAdd, PostOpt));
+      eunwrap(TA).TLI, eunwrap(TA), eunwrap(augmented), PostOpt));
 }
 EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
     EnzymeLogicRef Logic, LLVMValueRef todiff, CDIFFE_TYPE retType,

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -371,10 +371,20 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
     argnum++;
   }
   return wrap(eunwrap(Logic).CreatePrimalAndGradient(
-      cast<Function>(unwrap(todiff)), (DIFFE_TYPE)retType, nconstant_args,
-      eunwrap(TA).TLI, eunwrap(TA), returnValue, dretUsed, (DerivativeMode)mode,
-      unwrap(additionalArg), eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
-      uncacheable_args, eunwrap(augmented), AtomicAdd, PostOpt));
+      (ReverseCacheKey){
+        .todiff=cast<Function>(unwrap(todiff)),
+        .retType=(DIFFE_TYPE)retType,
+        .constant_args=nconstant_args,
+        .uncacheable_args=uncacheable_args,
+        .returnUsed=returnValue,
+        .shadowReturnUsed=dretUsed,
+        .mode=(DerivativeMode)mode,
+        .freeMemory=true,
+        .additionalType=unwrap(additionalArg),
+        .typeInfo=eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
+      },
+      eunwrap(TA).TLI, eunwrap(TA),
+      eunwrap(augmented), AtomicAdd, PostOpt));
 }
 EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
     EnzymeLogicRef Logic, LLVMValueRef todiff, CDIFFE_TYPE retType,

--- a/enzyme/Enzyme/CApi.cpp
+++ b/enzyme/Enzyme/CApi.cpp
@@ -372,19 +372,18 @@ LLVMValueRef EnzymeCreatePrimalAndGradient(
   }
   return wrap(eunwrap(Logic).CreatePrimalAndGradient(
       (ReverseCacheKey){
-        .todiff=cast<Function>(unwrap(todiff)),
-        .retType=(DIFFE_TYPE)retType,
-        .constant_args=nconstant_args,
-        .uncacheable_args=uncacheable_args,
-        .returnUsed=returnValue,
-        .shadowReturnUsed=dretUsed,
-        .mode=(DerivativeMode)mode,
-        .freeMemory=true,
-        .additionalType=unwrap(additionalArg),
-        .typeInfo=eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
+          .todiff = cast<Function>(unwrap(todiff)),
+          .retType = (DIFFE_TYPE)retType,
+          .constant_args = nconstant_args,
+          .uncacheable_args = uncacheable_args,
+          .returnUsed = returnValue,
+          .shadowReturnUsed = dretUsed,
+          .mode = (DerivativeMode)mode,
+          .freeMemory = true,
+          .additionalType = unwrap(additionalArg),
+          .typeInfo = eunwrap(typeInfo, cast<Function>(unwrap(todiff))),
       },
-      eunwrap(TA).TLI, eunwrap(TA),
-      eunwrap(augmented), AtomicAdd, PostOpt));
+      eunwrap(TA).TLI, eunwrap(TA), eunwrap(augmented), AtomicAdd, PostOpt));
 }
 EnzymeAugmentedReturnPtr EnzymeCreateAugmentedPrimal(
     EnzymeLogicRef Logic, LLVMValueRef todiff, CDIFFE_TYPE retType,

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -403,6 +403,8 @@ public:
     bool AtomicAdd = Arch == Triple::nvptx || Arch == Triple::nvptx64 ||
                      Arch == Triple::amdgcn;
 
+    bool freeMemory = true;
+
     bool differentialReturn =
         mode != DerivativeMode::ForwardMode &&
         mode != DerivativeMode::ReverseModePrimal &&
@@ -413,6 +415,7 @@ public:
     llvm::Value *tape = nullptr;
     bool tapeIsPointer = false;
     int allocatedTapeSize = -1;
+
 #if LLVM_VERSION_MAJOR >= 14
     for (unsigned i = 1 + sret; i < CI->arg_size(); ++i)
 #else
@@ -445,103 +448,72 @@ public:
       auto PTy = FT->getParamType(truei);
       DIFFE_TYPE ty = DIFFE_TYPE::CONSTANT;
 
-      if (auto av = dyn_cast<MetadataAsValue>(res)) {
-        auto MS = cast<MDString>(av->getMetadata())->getString();
-        if (MS == "enzyme_dup") {
+      // Returns if it should continue
+      bool error = false;
+      auto handleMetadata = [&](StringRef str) -> bool {
+        if (str == "enzyme_dup") {
           ty = DIFFE_TYPE::DUP_ARG;
-        } else if (MS == "enzyme_dupnoneed") {
+        } else if (str == "enzyme_dupnoneed") {
           ty = DIFFE_TYPE::DUP_NONEED;
-        } else if (MS == "enzyme_out") {
+        } else if (str == "enzyme_out") {
           ty = DIFFE_TYPE::OUT_DIFF;
-        } else if (MS == "enzyme_const") {
+        } else if (str == "enzyme_const") {
           ty = DIFFE_TYPE::CONSTANT;
-        } else if (MS == "enzyme_allocated") {
+        } else if (str == "enzyme_allocated") {
           assert(!sizeOnly);
           ++i;
           if (!isa<ConstantInt>(CI->getArgOperand(i))) {
             EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
                         "illegal enzyme allocated size ", *CI->getArgOperand(i),
                         "in", *CI);
+            error = true;
             return false;
           }
           allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
+              cast<ConstantInt>(CI->getArgOperand(i))->getZExtValue();
+          return true;
+        } else if (str == "enzyme_tape") {
           assert(!sizeOnly);
           ++i;
           tape = CI->getArgOperand(i);
           tapeIsPointer = true;
-          continue;
+          return true;
+        } else if (str == "enzyme_nofree") {
+          assert(!sizeOnly);
+          freeMemory = false;
+          return true;
         } else {
           EmitFailure("IllegalDiffeType", CI->getDebugLoc(), CI,
                       "illegal enzyme metadata classification ", *CI);
+          error = true;
           return false;
         }
         if (sizeOnly) {
           constants.push_back(ty);
-          continue;
+          return true;
         }
         ++i;
         res = CI->getArgOperand(i);
+        return false;
+      };
+#define HANDLE_MD(x)                                                           \
+  if (x.startswith("enzyme_")) {                                               \
+    auto res = handleMetadata(x);                                              \
+    if (error)                                                                 \
+      return false;                                                            \
+    if (res)                                                                   \
+      continue;                                                                \
+  }
+
+      if (auto av = dyn_cast<MetadataAsValue>(res)) {
+        auto MS = cast<MDString>(av->getMetadata())->getString();
+        HANDLE_MD(MS);
       } else if ((isa<LoadInst>(res) || isa<CastInst>(res)) &&
                  isa<GlobalVariable>(cast<Instruction>(res)->getOperand(0))) {
         GlobalVariable *gv =
             cast<GlobalVariable>(cast<Instruction>(res)->getOperand(0));
         auto MS = gv->getName();
-        if (MS == "enzyme_dup") {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_dupnoneed") {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_out") {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_const") {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else {
-          ty = whatType(PTy, mode);
-        }
+        HANDLE_MD(MS);
       } else if (isa<LoadInst>(res) &&
                  isa<ConstantExpr>(cast<LoadInst>(res)->getOperand(0)) &&
                  cast<ConstantExpr>(cast<LoadInst>(res)->getOperand(0))
@@ -552,268 +524,29 @@ public:
         auto gv = cast<GlobalVariable>(
             cast<ConstantExpr>(cast<LoadInst>(res)->getOperand(0))
                 ->getOperand(0));
+        ty = whatType(PTy, mode);
         auto MS = gv->getName();
-        if (MS == "enzyme_dup") {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_dupnoneed") {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_out") {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_const") {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else {
-          ty = whatType(PTy, mode);
-        }
-      } else if (isa<GlobalVariable>(res)) {
-        auto gv = cast<GlobalVariable>(res);
+        HANDLE_MD(MS);
+      } else if (auto gv = dyn_cast<GlobalVariable>(res)) {
+        ty = whatType(PTy, mode);
         auto MS = gv->getName();
-        if (MS == "enzyme_dup") {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_dupnoneed") {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_out") {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_const") {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else {
-          ty = whatType(PTy, mode);
-        }
+        HANDLE_MD(MS);
       } else if (isa<ConstantExpr>(res) && cast<ConstantExpr>(res)->isCast() &&
                  isa<GlobalVariable>(cast<ConstantExpr>(res)->getOperand(0))) {
         auto gv = cast<GlobalVariable>(cast<ConstantExpr>(res)->getOperand(0));
+        ty = whatType(PTy, mode);
         auto MS = gv->getName();
-        if (MS == "enzyme_dup") {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_dupnoneed") {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_out") {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_const") {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else {
-          ty = whatType(PTy, mode);
-        }
+        HANDLE_MD(MS);
       } else if (isa<CastInst>(res) && cast<CastInst>(res) &&
                  isa<AllocaInst>(cast<CastInst>(res)->getOperand(0))) {
         auto gv = cast<AllocaInst>(cast<CastInst>(res)->getOperand(0));
+        ty = whatType(PTy, mode);
         auto MS = gv->getName();
-        if (MS.startswith("enzyme_dup")) {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_dupnoneed")) {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_out")) {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_const")) {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS == "enzyme_allocated") {
-          assert(!sizeOnly);
-          ++i;
-          if (!isa<ConstantInt>(CI->getArgOperand(i))) {
-            EmitFailure("IllegalAllocatedSize", CI->getDebugLoc(), CI,
-                        "illegal enzyme allocated size ", *CI->getArgOperand(i),
-                        "in", *CI);
-            return false;
-          }
-          allocatedTapeSize =
-              cast<ConstantInt>(CI->getArgOperand(i))->getSExtValue();
-          continue;
-        } else if (MS == "enzyme_tape") {
-          assert(!sizeOnly);
-          ++i;
-          tape = CI->getArgOperand(i);
-          tapeIsPointer = true;
-          continue;
-        } else {
-          ty = whatType(PTy, mode);
-        }
-      } else if (isa<AllocaInst>(res)) {
-        auto gv = cast<AllocaInst>(res);
+        HANDLE_MD(MS);
+      } else if (auto gv = dyn_cast<AllocaInst>(res)) {
+        ty = whatType(PTy, mode);
         auto MS = gv->getName();
-        if (MS.startswith("enzyme_dup")) {
-          ty = DIFFE_TYPE::DUP_ARG;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_dupnoneed")) {
-          ty = DIFFE_TYPE::DUP_NONEED;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_out")) {
-          ty = DIFFE_TYPE::OUT_DIFF;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else if (MS.startswith("enzyme_const")) {
-          ty = DIFFE_TYPE::CONSTANT;
-          if (sizeOnly) {
-            constants.push_back(ty);
-            continue;
-          }
-          ++i;
-          res = CI->getArgOperand(i);
-        } else {
-          ty = whatType(PTy, mode);
-        }
+        HANDLE_MD(MS);
       } else
         ty = whatType(PTy, mode);
 
@@ -947,6 +680,8 @@ public:
     Type *tapeType = nullptr;
     const AugmentedReturn *aug;
     switch (mode) {
+    case DerivativeMode::ForwardModeVector:
+    case DerivativeMode::ForwardModeSplit:
     case DerivativeMode::ForwardMode:
       newFunc = Logic.CreateForwardDiff(
           cast<Function>(fn), retType, constants, TLI, TA,
@@ -954,20 +689,19 @@ public:
           /*addedType*/ nullptr, type_args, volatile_args, PostOpt);
       break;
     case DerivativeMode::ReverseModeCombined:
+      assert(freeMemory);
       newFunc = Logic.CreatePrimalAndGradient(
-          (ReverseCacheKey){
-            .todiff=cast<Function>(fn),
-            .retType=retType,
-            .constant_args=constants,
-            .uncacheable_args=volatile_args,
-            .returnUsed=false,
-            .shadowReturnUsed=false,
-            .mode=mode,
-            .freeMemory=true,
-            .additionalType=nullptr,
-            .typeInfo=type_args
-          },
-          TLI, TA, /*augmented*/nullptr, AtomicAdd, PostOpt);
+          (ReverseCacheKey){.todiff = cast<Function>(fn),
+                            .retType = retType,
+                            .constant_args = constants,
+                            .uncacheable_args = volatile_args,
+                            .returnUsed = false,
+                            .shadowReturnUsed = false,
+                            .mode = mode,
+                            .freeMemory = freeMemory,
+                            .additionalType = nullptr,
+                            .typeInfo = type_args},
+          TLI, TA, /*augmented*/ nullptr, AtomicAdd, PostOpt);
       break;
     case DerivativeMode::ReverseModePrimal:
     case DerivativeMode::ReverseModeGradient: {
@@ -1014,19 +748,17 @@ public:
         newFunc = aug->fn;
       else
         newFunc = Logic.CreatePrimalAndGradient(
-          (ReverseCacheKey){
-            .todiff=cast<Function>(fn),
-            .retType=retType,
-            .constant_args=constants,
-            .uncacheable_args=volatile_args,
-            .returnUsed=false,
-            .shadowReturnUsed=false,
-            .mode=mode,
-            .freeMemory=true,
-            .additionalType=tapeType,
-            .typeInfo=type_args
-          },
-          TLI, TA, aug, AtomicAdd, PostOpt);
+            (ReverseCacheKey){.todiff = cast<Function>(fn),
+                              .retType = retType,
+                              .constant_args = constants,
+                              .uncacheable_args = volatile_args,
+                              .returnUsed = false,
+                              .shadowReturnUsed = false,
+                              .mode = mode,
+                              .freeMemory = freeMemory,
+                              .additionalType = tapeType,
+                              .typeInfo = type_args},
+            TLI, TA, aug, AtomicAdd, PostOpt);
     }
     }
 
@@ -1154,8 +886,7 @@ public:
         Value *sret = CI->getArgOperand(0);
 
         if (StructType *st = cast<StructType>(diffret->getType())) {
-          for (unsigned int i = 0;
-               i < diffret->getType()->getStructNumElements(); i++) {
+          for (unsigned int i = 0; i < st->getNumElements(); i++) {
             Builder.CreateStore(Builder.CreateExtractValue(diffret, {i}),
                                 Builder.CreateStructGEP(sret, i));
           }

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -955,10 +955,19 @@ public:
       break;
     case DerivativeMode::ReverseModeCombined:
       newFunc = Logic.CreatePrimalAndGradient(
-          cast<Function>(fn), retType, constants, TLI, TA,
-          /*should return*/ false, /*dretPtr*/ false, mode,
-          /*addedType*/ nullptr, type_args, volatile_args,
-          /*index mapping*/ nullptr, AtomicAdd, PostOpt);
+          (ReverseCacheKey){
+            .todiff=cast<Function>(fn),
+            .retType=retType,
+            .constant_args=constants,
+            .uncacheable_args=volatile_args,
+            .returnUsed=false,
+            .shadowReturnUsed=false,
+            .mode=mode,
+            .freeMemory=true,
+            .additionalType=nullptr,
+            .typeInfo=type_args
+          },
+          TLI, TA, /*augmented*/nullptr, AtomicAdd, PostOpt);
       break;
     case DerivativeMode::ReverseModePrimal:
     case DerivativeMode::ReverseModeGradient: {
@@ -1005,9 +1014,19 @@ public:
         newFunc = aug->fn;
       else
         newFunc = Logic.CreatePrimalAndGradient(
-            cast<Function>(fn), retType, constants, TLI, TA,
-            /*should return*/ false, /*dretPtr*/ false, mode, tapeType,
-            type_args, volatile_args, aug, AtomicAdd, PostOpt);
+          (ReverseCacheKey){
+            .todiff=cast<Function>(fn),
+            .retType=retType,
+            .constant_args=constants,
+            .uncacheable_args=volatile_args,
+            .returnUsed=false,
+            .shadowReturnUsed=false,
+            .mode=mode,
+            .freeMemory=true,
+            .additionalType=tapeType,
+            .typeInfo=type_args
+          },
+          TLI, TA, aug, AtomicAdd, PostOpt);
     }
     }
 

--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -699,9 +699,10 @@ public:
                             .shadowReturnUsed = false,
                             .mode = mode,
                             .freeMemory = freeMemory,
+                            .AtomicAdd = AtomicAdd,
                             .additionalType = nullptr,
                             .typeInfo = type_args},
-          TLI, TA, /*augmented*/ nullptr, AtomicAdd, PostOpt);
+          TLI, TA, /*augmented*/ nullptr, PostOpt);
       break;
     case DerivativeMode::ReverseModePrimal:
     case DerivativeMode::ReverseModeGradient: {
@@ -756,9 +757,10 @@ public:
                               .shadowReturnUsed = false,
                               .mode = mode,
                               .freeMemory = freeMemory,
+                              .AtomicAdd = AtomicAdd,
                               .additionalType = tapeType,
                               .typeInfo = type_args},
-            TLI, TA, aug, AtomicAdd, PostOpt);
+            TLI, TA, aug, PostOpt);
     }
     }
 

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -2799,82 +2799,74 @@ void createInvertedTerminator(TypeResults &TR, DiffeGradientUtils *gutils,
 }
 
 Function *EnzymeLogic::CreatePrimalAndGradient(
-    Function *todiff, DIFFE_TYPE retType,
-    const std::vector<DIFFE_TYPE> &constant_args, TargetLibraryInfo &TLI,
-    TypeAnalysis &TA, bool returnUsed, bool dretPtr, DerivativeMode mode,
-    llvm::Type *additionalArg, const FnTypeInfo &oldTypeInfo_,
-    const std::map<Argument *, bool> _uncacheable_args,
+    const ReverseCacheKey&& key,
+    TargetLibraryInfo &TLI,
+    TypeAnalysis &TA, 
     const AugmentedReturn *augmenteddata, bool AtomicAdd, bool PostOpt,
     bool omp) {
 
-  assert(mode == DerivativeMode::ReverseModeCombined ||
-         mode == DerivativeMode::ReverseModeGradient);
+  assert(key.mode == DerivativeMode::ReverseModeCombined ||
+         key.mode == DerivativeMode::ReverseModeGradient);
 
-  FnTypeInfo oldTypeInfo = preventTypeAnalysisLoops(oldTypeInfo_, todiff);
+  FnTypeInfo oldTypeInfo = preventTypeAnalysisLoops(key.typeInfo, key.todiff);
 
-  if (retType != DIFFE_TYPE::CONSTANT)
-    assert(!todiff->getReturnType()->isVoidTy());
-
-  ReverseCacheKey tup =
-      std::make_tuple(todiff, retType, constant_args,
-                      std::map<Argument *, bool>(_uncacheable_args.begin(),
-                                                 _uncacheable_args.end()),
-                      returnUsed, dretPtr, mode, additionalArg, oldTypeInfo);
-  if (ReverseCachedFunctions.find(tup) != ReverseCachedFunctions.end()) {
-    return ReverseCachedFunctions.find(tup)->second;
+  if (key.retType != DIFFE_TYPE::CONSTANT)
+    assert(!key.todiff->getReturnType()->isVoidTy());
+  if (ReverseCachedFunctions.find(key) != ReverseCachedFunctions.end()) {
+    return ReverseCachedFunctions.find(key)->second;
   }
 
   // Whether we shuold actually return the value
   bool returnValue =
-      returnUsed && (mode == DerivativeMode::ReverseModeCombined);
+      key.returnUsed && (key.mode == DerivativeMode::ReverseModeCombined);
 
   // TODO change this to go by default function type assumptions
   bool hasconstant = false;
-  for (auto v : constant_args) {
+  for (auto v : key.constant_args) {
     if (v == DIFFE_TYPE::CONSTANT) {
       hasconstant = true;
       break;
     }
   }
 
-  if (hasMetadata(todiff, "enzyme_gradient")) {
+  if (hasMetadata(key.todiff, "enzyme_gradient")) {
 
-    DIFFE_TYPE subretType = todiff->getReturnType()->isFPOrFPVectorTy()
+    DIFFE_TYPE subretType = key.todiff->getReturnType()->isFPOrFPVectorTy()
                                 ? DIFFE_TYPE::OUT_DIFF
                                 : DIFFE_TYPE::DUP_ARG;
-    if (todiff->getReturnType()->isVoidTy() ||
-        todiff->getReturnType()->isEmptyTy())
+    if (key.todiff->getReturnType()->isVoidTy() ||
+        key.todiff->getReturnType()->isEmptyTy())
       subretType = DIFFE_TYPE::CONSTANT;
-    assert(subretType == retType);
+    assert(subretType == key.retType);
 
-    auto res = getDefaultFunctionTypeForGradient(todiff->getFunctionType(),
-                                                 /*retType*/ retType);
+    auto res = getDefaultFunctionTypeForGradient(key.todiff->getFunctionType(),
+                                                 /*retType*/ key.retType);
 
-    if (mode == DerivativeMode::ReverseModeCombined) {
+    if (key.mode == DerivativeMode::ReverseModeCombined) {
 
       Type *FRetTy = res.second.empty()
-                         ? Type::getVoidTy(todiff->getContext())
-                         : StructType::get(todiff->getContext(), {res.second});
+                         ? Type::getVoidTy(key.todiff->getContext())
+                         : StructType::get(key.todiff->getContext(), {res.second});
 
       FunctionType *FTy = FunctionType::get(
-          FRetTy, res.first, todiff->getFunctionType()->isVarArg());
+          FRetTy, res.first, key.todiff->getFunctionType()->isVarArg());
 
       Function *NewF = Function::Create(
           FTy, Function::LinkageTypes::InternalLinkage,
-          "fixgradient_" + todiff->getName(), todiff->getParent());
+          "fixgradient_" + key.todiff->getName(), key.todiff->getParent());
 
       BasicBlock *BB = BasicBlock::Create(NewF->getContext(), "entry", NewF);
       IRBuilder<> bb(BB);
 
       auto &aug = CreateAugmentedPrimal(
-          todiff, retType, constant_args, TLI, TA, returnUsed, oldTypeInfo_,
-          _uncacheable_args, /*forceAnonymousTape*/ false, AtomicAdd, PostOpt,
+          key.todiff, key.retType, key.constant_args, TLI, TA, key.returnUsed, key.typeInfo,
+          key.uncacheable_args, /*forceAnonymousTape*/ false, AtomicAdd, PostOpt,
           omp);
 
       SmallVector<Value *, 4> fwdargs;
       for (auto &a : NewF->args())
         fwdargs.push_back(&a);
-      if (retType == DIFFE_TYPE::OUT_DIFF)
+      if (key.retType == DIFFE_TYPE::OUT_DIFF)
         fwdargs.pop_back();
       auto cal = bb.CreateCall(aug.fn, fwdargs);
       cal->setCallingConv(aug.fn->getCallingConv());
@@ -2901,11 +2893,20 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
 
       auto revfn = CreatePrimalAndGradient(
-          todiff, retType, constant_args, TLI, TA,
-          /*returnUsed*/ false, /*dretPtr*/ false,
-          /*mode*/ DerivativeMode::ReverseModeGradient,
-          /*additionalArg*/ tape ? tape->getType() : nullptr, oldTypeInfo_,
-          _uncacheable_args, &aug, AtomicAdd, PostOpt, omp);
+          (ReverseCacheKey){
+            .todiff=key.todiff,
+            .retType=key.retType,
+            .constant_args=key.constant_args,
+            .uncacheable_args=key.uncacheable_args,
+            .returnUsed=false,
+            .shadowReturnUsed=false,
+            .mode=DerivativeMode::ReverseModeGradient,
+            .freeMemory=key.freeMemory,
+            .additionalType=tape ? tape->getType() : nullptr,
+            .typeInfo=key.typeInfo
+          },
+          TLI, TA,
+          &aug, AtomicAdd, PostOpt, omp);
 
       SmallVector<Value *, 4> revargs;
       for (auto &a : NewF->args()) {
@@ -2924,16 +2925,16 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       } else {
         bb.CreateRet(revcal);
       }
-      assert(!returnUsed);
+      assert(!key.returnUsed);
 
       return insert_or_assign2<ReverseCacheKey, Function *>(
-                 ReverseCachedFunctions, tup, NewF)
+                 ReverseCachedFunctions, key, NewF)
           ->second;
     }
 
-    auto md = todiff->getMetadata("enzyme_gradient");
+    auto md = key.todiff->getMetadata("enzyme_gradient");
     if (!isa<MDTuple>(md)) {
-      llvm::errs() << *todiff << "\n";
+      llvm::errs() << *key.todiff << "\n";
       llvm::errs() << *md << "\n";
       report_fatal_error(
           "unknown gradient for noninvertible function -- metadata incorrect");
@@ -2944,16 +2945,16 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
     auto foundcalled = cast<Function>(gvemd->getValue());
 
     if (hasconstant) {
-      EmitWarning("NoCustom", todiff->getEntryBlock().begin()->getDebugLoc(),
-                  todiff, &todiff->getEntryBlock(),
+      EmitWarning("NoCustom", key.todiff->getEntryBlock().begin()->getDebugLoc(),
+                  key.todiff, &key.todiff->getEntryBlock(),
                   "Massaging provided custom reverse pass");
       SmallVector<Type *, 3> dupargs;
-      std::vector<DIFFE_TYPE> next_constant_args(constant_args);
+      std::vector<DIFFE_TYPE> next_constant_args(key.constant_args);
       {
-        auto OFT = todiff->getFunctionType();
-        for (size_t act_idx = 0; act_idx < constant_args.size(); act_idx++) {
+        auto OFT = key.todiff->getFunctionType();
+        for (size_t act_idx = 0; act_idx < key.constant_args.size(); act_idx++) {
           dupargs.push_back(OFT->getParamType(act_idx));
-          switch (constant_args[act_idx]) {
+          switch (key.constant_args[act_idx]) {
           case DIFFE_TYPE::OUT_DIFF:
             break;
           case DIFFE_TYPE::DUP_ARG:
@@ -2972,11 +2973,20 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
 
       auto revfn = CreatePrimalAndGradient(
-          todiff, retType, next_constant_args, TLI, TA,
-          /*returnUsed*/ returnUsed, /*dretPtr*/ false,
-          /*mode*/ DerivativeMode::ReverseModeGradient,
-          /*additionalArg (not used, TODO)*/ nullptr, oldTypeInfo_,
-          _uncacheable_args, augmenteddata, AtomicAdd, PostOpt, omp);
+          (ReverseCacheKey){
+            .todiff=key.todiff,
+            .retType=key.retType,
+            .constant_args=next_constant_args,
+            .uncacheable_args=key.uncacheable_args,
+            .returnUsed=key.returnUsed,
+            .shadowReturnUsed=false,
+            .mode=DerivativeMode::ReverseModeGradient,
+            .freeMemory=key.freeMemory,
+            .additionalType=nullptr,
+            .typeInfo=key.typeInfo
+          },
+          TLI, TA,
+          augmenteddata, AtomicAdd, PostOpt, omp);
 
       {
         auto arg = revfn->arg_begin();
@@ -2996,16 +3006,16 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                             revfn->getFunctionType()->isVarArg());
       Function *NewF = Function::Create(
           FTy, Function::LinkageTypes::InternalLinkage,
-          "fixgradient_" + todiff->getName(), todiff->getParent());
+          "fixgradient_" + key.todiff->getName(), key.todiff->getParent());
 
       BasicBlock *BB = BasicBlock::Create(NewF->getContext(), "entry", NewF);
       IRBuilder<> bb(BB);
       auto arg = NewF->arg_begin();
       SmallVector<Value *, 3> revargs;
       size_t act_idx = 0;
-      while (act_idx != constant_args.size()) {
+      while (act_idx != key.constant_args.size()) {
         revargs.push_back(arg);
-        switch (constant_args[act_idx]) {
+        switch (key.constant_args[act_idx]) {
         case DIFFE_TYPE::OUT_DIFF:
           break;
         case DIFFE_TYPE::DUP_ARG:
@@ -3037,11 +3047,11 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
         bb.CreateRet(cal);
 
       return insert_or_assign2<ReverseCacheKey, Function *>(
-                 ReverseCachedFunctions, tup, NewF)
+                 ReverseCachedFunctions, key, NewF)
           ->second;
     }
 
-    if (!returnValue) {
+    if (!key.returnUsed) {
 
       assert(augmenteddata);
       if (foundcalled->arg_size() == res.first.size() + 1 /*tape*/) {
@@ -3068,14 +3078,14 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
         // if (wrongRet || !hasTape) {
         Type *FRetTy =
             res.second.empty()
-                ? Type::getVoidTy(todiff->getContext())
-                : StructType::get(todiff->getContext(), {res.second});
+                ? Type::getVoidTy(key.todiff->getContext())
+                : StructType::get(key.todiff->getContext(), {res.second});
 
         FunctionType *FTy = FunctionType::get(
-            FRetTy, res.first, todiff->getFunctionType()->isVarArg());
+            FRetTy, res.first, key.todiff->getFunctionType()->isVarArg());
         Function *NewF = Function::Create(
             FTy, Function::LinkageTypes::InternalLinkage,
-            "fixgradient_" + todiff->getName(), todiff->getParent());
+            "fixgradient_" + key.todiff->getName(), key.todiff->getParent());
         NewF->setAttributes(foundcalled->getAttributes());
         if (NewF->hasFnAttribute(Attribute::NoInline)) {
           NewF->removeFnAttr(Attribute::NoInline);
@@ -3118,31 +3128,31 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
         foundcalled = NewF;
       }
       return insert_or_assign2<ReverseCacheKey, Function *>(
-                 ReverseCachedFunctions, tup, foundcalled)
+                 ReverseCachedFunctions, key, foundcalled)
           ->second;
     }
 
-    EmitWarning("NoCustom", todiff->getEntryBlock().begin()->getDebugLoc(),
-                todiff, &todiff->getEntryBlock(),
+    EmitWarning("NoCustom", key.todiff->getEntryBlock().begin()->getDebugLoc(),
+                key.todiff, &key.todiff->getEntryBlock(),
                 "Not using provided custom reverse pass as require either "
                 "return or non-constant");
   }
 
-  assert(!todiff->empty());
+  assert(!key.todiff->empty());
 
   ReturnType retVal =
-      returnValue ? (dretPtr ? ReturnType::ArgsWithTwoReturns
+      key.returnUsed ? (key.shadowReturnUsed ? ReturnType::ArgsWithTwoReturns
                              : ReturnType::ArgsWithReturn)
-                  : (dretPtr ? ReturnType::ArgsWithReturn : ReturnType::Args);
+                  : (key.shadowReturnUsed ? ReturnType::ArgsWithReturn : ReturnType::Args);
 
-  bool diffeReturnArg = retType == DIFFE_TYPE::OUT_DIFF;
+  bool diffeReturnArg = key.retType == DIFFE_TYPE::OUT_DIFF;
 
   DiffeGradientUtils *gutils = DiffeGradientUtils::CreateFromClone(
-      *this, mode, todiff, TLI, TA, retType, diffeReturnArg, constant_args,
-      retVal, additionalArg, omp);
+      *this, key.mode, key.todiff, TLI, TA,key. retType, diffeReturnArg, key.constant_args,
+      retVal, key.additionalType, omp);
 
   gutils->AtomicAdd = AtomicAdd;
-  insert_or_assign2<ReverseCacheKey, Function *>(ReverseCachedFunctions, tup,
+  insert_or_assign2<ReverseCacheKey, Function *>(ReverseCachedFunctions, key,
                                                  gutils->newFunc);
 
   const SmallPtrSet<BasicBlock *, 4> guaranteedUnreachable =
@@ -3152,10 +3162,10 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   // function
   std::map<Argument *, bool> _uncacheable_argsPP;
   {
-    auto in_arg = todiff->arg_begin();
+    auto in_arg = key.todiff->arg_begin();
     auto pp_arg = gutils->oldFunc->arg_begin();
     for (; pp_arg != gutils->oldFunc->arg_end();) {
-      _uncacheable_argsPP[pp_arg] = _uncacheable_args.find(in_arg)->second;
+      _uncacheable_argsPP[pp_arg] = key.uncacheable_args.find(in_arg)->second;
       ++pp_arg;
       ++in_arg;
     }
@@ -3163,9 +3173,9 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
 
   FnTypeInfo typeInfo(gutils->oldFunc);
   {
-    auto toarg = todiff->arg_begin();
+    auto toarg = key.todiff->arg_begin();
     auto olarg = gutils->oldFunc->arg_begin();
-    for (; toarg != todiff->arg_end(); ++toarg, ++olarg) {
+    for (; toarg != key.todiff->arg_end(); ++toarg, ++olarg) {
 
       {
         auto fd = oldTypeInfo.Arguments.find(toarg);
@@ -3203,7 +3213,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                    gutils->oldFunc,
                    PPC.FAM.getResult<ScalarEvolutionAnalysis>(*gutils->oldFunc),
                    gutils->OrigLI, gutils->OrigDT, TLI,
-                   unnecessaryInstructionsTmp, _uncacheable_argsPP, mode, omp);
+                   unnecessaryInstructionsTmp, _uncacheable_argsPP, key.mode, omp);
   const std::map<CallInst *, const std::map<Argument *, bool>>
       uncacheable_args_map =
           (augmenteddata) ? augmenteddata->uncacheable_args_map
@@ -3227,19 +3237,19 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   SmallPtrSet<const Value *, 4> unnecessaryValues;
   SmallPtrSet<const Instruction *, 4> unnecessaryInstructions;
   calculateUnusedValuesInFunction(
-      *gutils->oldFunc, unnecessaryValues, unnecessaryInstructions, returnValue,
-      mode, TR, gutils, TLI, constant_args, guaranteedUnreachable);
+      *gutils->oldFunc, unnecessaryValues, unnecessaryInstructions, key.returnUsed,
+      key.mode, TR, gutils, TLI, key.constant_args, guaranteedUnreachable);
 
   SmallPtrSet<const Instruction *, 4> unnecessaryStores;
   calculateUnusedStoresInFunction(*gutils->oldFunc, unnecessaryStores,
                                   unnecessaryInstructions, gutils);
 
   Value *additionalValue = nullptr;
-  if (additionalArg) {
+  if (key.additionalType) {
     auto v = gutils->newFunc->arg_end();
     v--;
     additionalValue = v;
-    assert(mode != DerivativeMode::ReverseModeCombined);
+    assert(key.mode != DerivativeMode::ReverseModeCombined);
     assert(augmenteddata);
 
     // TODO VERIFY THIS
@@ -3274,17 +3284,17 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   }
 
   Argument *differetval = nullptr;
-  if (retType == DIFFE_TYPE::OUT_DIFF) {
+  if (key.retType == DIFFE_TYPE::OUT_DIFF) {
     auto endarg = gutils->newFunc->arg_end();
     endarg--;
-    if (additionalArg)
+    if (key.additionalType)
       endarg--;
     differetval = endarg;
-    if (differetval->getType() != todiff->getReturnType()) {
+    if (differetval->getType() != key.todiff->getReturnType()) {
       llvm::errs() << *gutils->oldFunc << "\n";
       llvm::errs() << *gutils->newFunc << "\n";
     }
-    assert(differetval->getType() == todiff->getReturnType());
+    assert(differetval->getType() == key.todiff->getReturnType());
   }
 
   // Explicitly handle all returns first to ensure that return instructions know
@@ -3293,19 +3303,19 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   std::map<ReturnInst *, StoreInst *> replacedReturns;
   llvm::AllocaInst *retAlloca = nullptr;
   llvm::AllocaInst *dretAlloca = nullptr;
-  if (returnValue) {
+  if (key.returnUsed) {
     retAlloca = IRBuilder<>(&gutils->newFunc->getEntryBlock().front())
-                    .CreateAlloca(todiff->getReturnType(), nullptr, "toreturn");
+                    .CreateAlloca(key.todiff->getReturnType(), nullptr, "toreturn");
   }
-  if (dretPtr) {
-    assert(retType == DIFFE_TYPE::DUP_ARG || retType == DIFFE_TYPE::DUP_NONEED);
-    assert(mode == DerivativeMode::ReverseModeCombined);
+  if (key.shadowReturnUsed) {
+    assert(key.retType == DIFFE_TYPE::DUP_ARG || key.retType == DIFFE_TYPE::DUP_NONEED);
+    assert(key.mode == DerivativeMode::ReverseModeCombined);
     dretAlloca =
         IRBuilder<>(&gutils->newFunc->getEntryBlock().front())
-            .CreateAlloca(todiff->getReturnType(), nullptr, "dtoreturn");
+            .CreateAlloca(key.todiff->getReturnType(), nullptr, "dtoreturn");
   }
-  if (mode == DerivativeMode::ReverseModeCombined ||
-      mode == DerivativeMode::ReverseModeGradient) {
+  if (key.mode == DerivativeMode::ReverseModeCombined ||
+      key.mode == DerivativeMode::ReverseModeGradient) {
     for (BasicBlock &oBB : *gutils->oldFunc) {
       if (ReturnInst *orig = dyn_cast<ReturnInst>(oBB.getTerminator())) {
         ReturnInst *op = cast<ReturnInst>(gutils->getNewFromOriginal(orig));
@@ -3324,7 +3334,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
                          dretAlloca);
         }
 
-        if (retType == DIFFE_TYPE::OUT_DIFF) {
+        if (key.retType == DIFFE_TYPE::OUT_DIFF) {
           assert(orig->getReturnValue());
           assert(differetval);
           if (!gutils->isConstantValue(orig->getReturnValue())) {
@@ -3342,7 +3352,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
   }
 
   AdjointGenerator<const AugmentedReturn *> maker(
-      mode, gutils, constant_args, retType, TR, getIndex, uncacheable_args_map,
+      key.mode, gutils, key.constant_args, key.retType, TR, getIndex, uncacheable_args_map,
       /*returnuses*/ nullptr, augmenteddata, &replacedReturns,
       unnecessaryValues, unnecessaryInstructions, unnecessaryStores,
       guaranteedUnreachable, dretAlloca);
@@ -3372,7 +3382,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       }
       for (auto I : toerase) {
         maker.eraseIfUnused(*I, /*erase*/ true,
-                            /*check*/ mode ==
+                            /*check*/ key.mode ==
                                 DerivativeMode::ReverseModeCombined);
       }
       if (newBB->getTerminator())
@@ -3398,17 +3408,17 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       assert(oBB.rend() == E);
     }
 
-    createInvertedTerminator(TR, gutils, constant_args, &oBB, retAlloca,
+    createInvertedTerminator(TR, gutils, key.constant_args, &oBB, retAlloca,
                              dretAlloca,
-                             0 + (additionalArg ? 1 : 0) +
-                                 ((retType == DIFFE_TYPE::DUP_ARG ||
-                                   retType == DIFFE_TYPE::DUP_NONEED)
+                             0 + (key.additionalType ? 1 : 0) +
+                                 ((key.retType == DIFFE_TYPE::DUP_ARG ||
+                                   key.retType == DIFFE_TYPE::DUP_NONEED)
                                       ? 1
                                       : 0),
-                             retType);
+                             key.retType);
   }
 
-  if (mode != DerivativeMode::ReverseModeCombined) {
+  if (key.mode != DerivativeMode::ReverseModeCombined) {
     // One must use this temporary map to first create all the replacements
     // prior to actually replacing to ensure that getSubLimits has the same
     // behavior and unwrap behavior for all replacements.
@@ -3563,7 +3573,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
       Arch == Triple::amdgcn ? (int)AMDGPU::HSAMD::AddressSpaceQualifier::Local
                              : 3;
 
-  if (mode == DerivativeMode::ReverseModeCombined) {
+  if (key.mode == DerivativeMode::ReverseModeCombined) {
     BasicBlock *sharedBlock = nullptr;
     for (auto &g : gutils->newFunc->getParent()->globals()) {
       if (hasMetadata(&g, "enzyme_internalshadowglobal")) {
@@ -3738,7 +3748,7 @@ Function *EnzymeLogic::CreateForwardDiff(
       *this, mode, todiff, TLI, TA, retType, diffeReturnArg, constant_args,
       retVal, additionalArg, omp);
 
-  insert_or_assign2<ReverseCacheKey, Function *>(ReverseCachedFunctions, tup,
+  insert_or_assign2<ForwardCacheKey, Function *>(ForwardCachedFunctions, tup,
                                                  gutils->newFunc);
 
   const SmallPtrSet<BasicBlock *, 4> guaranteedUnreachable =

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -135,6 +135,7 @@ struct ReverseCacheKey {
   bool shadowReturnUsed;
   DerivativeMode mode;
   bool freeMemory;
+  bool AtomicAdd;
   llvm::Type *additionalType;
   const FnTypeInfo typeInfo;
 
@@ -148,6 +149,7 @@ struct ReverseCacheKey {
              shadowReturnUsed == rhs.shadowReturnUsed &&
              mode == rhs.mode &&
              freeMemory == rhs.freeMemory &&
+             AtomicAdd == rhs.AtomicAdd &&
              additionalType == rhs.additionalType &&
              typeInfo == rhs.typeInfo;
   }
@@ -198,6 +200,11 @@ struct ReverseCacheKey {
     if (freeMemory < rhs.freeMemory)
       return true;
     if (rhs.freeMemory < freeMemory)
+      return false;
+
+    if (AtomicAdd < rhs.AtomicAdd)
+      return true;
+    if (rhs.AtomicAdd < AtomicAdd)
       return false;
 
     if (additionalType < rhs.additionalType)
@@ -273,7 +280,7 @@ public:
                                           llvm::TargetLibraryInfo &TLI,
                                           TypeAnalysis &TA,
                                           const AugmentedReturn *augmented,
-                                          bool AtomicAdd, bool PostOpt = false,
+                                          bool PostOpt = false,
                                           bool omp = false);
 
   llvm::Function *

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -126,6 +126,94 @@ public:
         can_modref_map(can_modref_map) {}
 };
 
+struct ReverseCacheKey {
+    llvm::Function *todiff;
+    DIFFE_TYPE retType;
+    const std::vector<DIFFE_TYPE> constant_args;
+    std::map<llvm::Argument*, bool> uncacheable_args;
+    bool returnUsed;
+    bool shadowReturnUsed;
+    DerivativeMode mode;
+    bool freeMemory;
+    llvm::Type* additionalType;
+    const FnTypeInfo typeInfo;
+
+    /*
+    inline bool operator==(const ReverseCacheKey& rhs) const {
+        return todiff == rhs.todiff &&
+               retType == rhs.retType &&
+               constant_args == rhs.constant_args &&
+               uncacheable_args == rhs.uncacheable_args &&
+               returnUsed == rhs.returnUsed &&
+               shadowReturnUsed == rhs.shadowReturnUsed &&
+               mode == rhs.mode &&
+               freeMemory == rhs.freeMemory &&
+               additionalType == rhs.additionalType &&
+               typeInfo == rhs.typeInfo;
+    }
+    */
+
+    inline bool operator<(const ReverseCacheKey& rhs) const {
+        if (todiff < rhs.todiff)
+            return true;
+        if (rhs.todiff < todiff)
+            return false;
+
+        if (retType < rhs.retType)
+            return true;
+        if (rhs.retType < retType)
+            return false;
+
+        if (constant_args < rhs.constant_args)
+            return true;
+        if (rhs.constant_args < constant_args)
+            return false;
+
+        for (auto &arg : todiff->args()) {
+            auto foundLHS = uncacheable_args.find(&arg);
+            assert(foundLHS != uncacheable_args.end());
+            auto foundRHS = rhs.uncacheable_args.find(&arg);
+            assert(foundRHS != rhs.uncacheable_args.end());
+            if (foundLHS->second < foundRHS->second)
+                return true;
+            if (foundRHS->second < foundLHS->second)
+                return false;
+        }
+    
+        if (returnUsed < rhs.returnUsed)
+            return true;
+        if (rhs.returnUsed < returnUsed)
+            return false;
+        
+        if (shadowReturnUsed < rhs.shadowReturnUsed)
+            return true;
+        if (rhs.shadowReturnUsed < shadowReturnUsed)
+            return false;
+        
+        if (mode < rhs.mode)
+            return true;
+        if (rhs.mode < mode)
+            return false;
+        
+        if (freeMemory < rhs.freeMemory)
+            return true;
+        if (rhs.freeMemory < freeMemory)
+            return false;
+        
+        if (additionalType < rhs.additionalType)
+            return true;
+        if (rhs.additionalType < additionalType)
+            return false;
+        
+        if (typeInfo < rhs.typeInfo)
+            return true;
+        if (rhs.typeInfo < typeInfo)
+            return false;
+        // equal
+        return false;
+    }
+};
+
 class EnzymeLogic {
 public:
   PreProcessCache PPC;
@@ -157,12 +245,6 @@ public:
       const std::map<llvm::Argument *, bool> _uncacheable_args,
       bool forceAnonymousTape, bool AtomicAdd, bool PostOpt, bool omp = false);
 
-  using ReverseCacheKey =
-      std::tuple<llvm::Function *, DIFFE_TYPE /*retType*/,
-                 std::vector<DIFFE_TYPE> /*constant_args*/,
-                 std::map<llvm::Argument *, bool> /*uncacheable_args*/,
-                 bool /*retval*/, bool /*dretPtr*/, DerivativeMode,
-                 llvm::Type *, const FnTypeInfo>;
   std::map<ReverseCacheKey, llvm::Function *> ReverseCachedFunctions;
 
   using ForwardCacheKey =
@@ -188,12 +270,9 @@ public:
   ///  updates to memory in an atomic way \p PostOpt is whether to perform basic
   ///  optimization of the function after synthesis
   llvm::Function *CreatePrimalAndGradient(
-      llvm::Function *todiff, DIFFE_TYPE retType,
-      const std::vector<DIFFE_TYPE> &constant_args,
-      llvm::TargetLibraryInfo &TLI, TypeAnalysis &TA, bool returnValue,
-      bool dretUsed, DerivativeMode mode, llvm::Type *additionalArg,
-      const FnTypeInfo &typeInfo,
-      const std::map<llvm::Argument *, bool> _uncacheable_args,
+      const ReverseCacheKey&& key,
+      llvm::TargetLibraryInfo &TLI,
+      TypeAnalysis &TA,
       const AugmentedReturn *augmented, bool AtomicAdd, bool PostOpt = false,
       bool omp = false);
 

--- a/enzyme/Enzyme/EnzymeLogic.h
+++ b/enzyme/Enzyme/EnzymeLogic.h
@@ -127,91 +127,91 @@ public:
 };
 
 struct ReverseCacheKey {
-    llvm::Function *todiff;
-    DIFFE_TYPE retType;
-    const std::vector<DIFFE_TYPE> constant_args;
-    std::map<llvm::Argument*, bool> uncacheable_args;
-    bool returnUsed;
-    bool shadowReturnUsed;
-    DerivativeMode mode;
-    bool freeMemory;
-    llvm::Type* additionalType;
-    const FnTypeInfo typeInfo;
+  llvm::Function *todiff;
+  DIFFE_TYPE retType;
+  const std::vector<DIFFE_TYPE> constant_args;
+  std::map<llvm::Argument *, bool> uncacheable_args;
+  bool returnUsed;
+  bool shadowReturnUsed;
+  DerivativeMode mode;
+  bool freeMemory;
+  llvm::Type *additionalType;
+  const FnTypeInfo typeInfo;
 
-    /*
-    inline bool operator==(const ReverseCacheKey& rhs) const {
-        return todiff == rhs.todiff &&
-               retType == rhs.retType &&
-               constant_args == rhs.constant_args &&
-               uncacheable_args == rhs.uncacheable_args &&
-               returnUsed == rhs.returnUsed &&
-               shadowReturnUsed == rhs.shadowReturnUsed &&
-               mode == rhs.mode &&
-               freeMemory == rhs.freeMemory &&
-               additionalType == rhs.additionalType &&
-               typeInfo == rhs.typeInfo;
-    }
-    */
+  /*
+  inline bool operator==(const ReverseCacheKey& rhs) const {
+      return todiff == rhs.todiff &&
+             retType == rhs.retType &&
+             constant_args == rhs.constant_args &&
+             uncacheable_args == rhs.uncacheable_args &&
+             returnUsed == rhs.returnUsed &&
+             shadowReturnUsed == rhs.shadowReturnUsed &&
+             mode == rhs.mode &&
+             freeMemory == rhs.freeMemory &&
+             additionalType == rhs.additionalType &&
+             typeInfo == rhs.typeInfo;
+  }
+  */
 
-    inline bool operator<(const ReverseCacheKey& rhs) const {
-        if (todiff < rhs.todiff)
-            return true;
-        if (rhs.todiff < todiff)
-            return false;
+  inline bool operator<(const ReverseCacheKey &rhs) const {
+    if (todiff < rhs.todiff)
+      return true;
+    if (rhs.todiff < todiff)
+      return false;
 
-        if (retType < rhs.retType)
-            return true;
-        if (rhs.retType < retType)
-            return false;
+    if (retType < rhs.retType)
+      return true;
+    if (rhs.retType < retType)
+      return false;
 
-        if (constant_args < rhs.constant_args)
-            return true;
-        if (rhs.constant_args < constant_args)
-            return false;
+    if (constant_args < rhs.constant_args)
+      return true;
+    if (rhs.constant_args < constant_args)
+      return false;
 
-        for (auto &arg : todiff->args()) {
-            auto foundLHS = uncacheable_args.find(&arg);
-            assert(foundLHS != uncacheable_args.end());
-            auto foundRHS = rhs.uncacheable_args.find(&arg);
-            assert(foundRHS != rhs.uncacheable_args.end());
-            if (foundLHS->second < foundRHS->second)
-                return true;
-            if (foundRHS->second < foundLHS->second)
-                return false;
-        }
-    
-        if (returnUsed < rhs.returnUsed)
-            return true;
-        if (rhs.returnUsed < returnUsed)
-            return false;
-        
-        if (shadowReturnUsed < rhs.shadowReturnUsed)
-            return true;
-        if (rhs.shadowReturnUsed < shadowReturnUsed)
-            return false;
-        
-        if (mode < rhs.mode)
-            return true;
-        if (rhs.mode < mode)
-            return false;
-        
-        if (freeMemory < rhs.freeMemory)
-            return true;
-        if (rhs.freeMemory < freeMemory)
-            return false;
-        
-        if (additionalType < rhs.additionalType)
-            return true;
-        if (rhs.additionalType < additionalType)
-            return false;
-        
-        if (typeInfo < rhs.typeInfo)
-            return true;
-        if (rhs.typeInfo < typeInfo)
-            return false;
-        // equal
+    for (auto &arg : todiff->args()) {
+      auto foundLHS = uncacheable_args.find(&arg);
+      assert(foundLHS != uncacheable_args.end());
+      auto foundRHS = rhs.uncacheable_args.find(&arg);
+      assert(foundRHS != rhs.uncacheable_args.end());
+      if (foundLHS->second < foundRHS->second)
+        return true;
+      if (foundRHS->second < foundLHS->second)
         return false;
     }
+
+    if (returnUsed < rhs.returnUsed)
+      return true;
+    if (rhs.returnUsed < returnUsed)
+      return false;
+
+    if (shadowReturnUsed < rhs.shadowReturnUsed)
+      return true;
+    if (rhs.shadowReturnUsed < shadowReturnUsed)
+      return false;
+
+    if (mode < rhs.mode)
+      return true;
+    if (rhs.mode < mode)
+      return false;
+
+    if (freeMemory < rhs.freeMemory)
+      return true;
+    if (rhs.freeMemory < freeMemory)
+      return false;
+
+    if (additionalType < rhs.additionalType)
+      return true;
+    if (rhs.additionalType < additionalType)
+      return false;
+
+    if (typeInfo < rhs.typeInfo)
+      return true;
+    if (rhs.typeInfo < typeInfo)
+      return false;
+    // equal
+    return false;
+  }
 };
 
 class EnzymeLogic {
@@ -269,12 +269,12 @@ public:
   ///  an augmented forward pass \p AtomicAdd is whether to perform all adjoint
   ///  updates to memory in an atomic way \p PostOpt is whether to perform basic
   ///  optimization of the function after synthesis
-  llvm::Function *CreatePrimalAndGradient(
-      const ReverseCacheKey&& key,
-      llvm::TargetLibraryInfo &TLI,
-      TypeAnalysis &TA,
-      const AugmentedReturn *augmented, bool AtomicAdd, bool PostOpt = false,
-      bool omp = false);
+  llvm::Function *CreatePrimalAndGradient(const ReverseCacheKey &&key,
+                                          llvm::TargetLibraryInfo &TLI,
+                                          TypeAnalysis &TA,
+                                          const AugmentedReturn *augmented,
+                                          bool AtomicAdd, bool PostOpt = false,
+                                          bool omp = false);
 
   llvm::Function *
   CreateForwardDiff(llvm::Function *todiff, DIFFE_TYPE retType,

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2679,11 +2679,19 @@ Constant *GradientUtils::GetOrCreateShadowFunction(EnzymeLogic &Logic,
       type_args, uncacheable_args, /*forceAnonymousTape*/ true, AtomicAdd,
       PostOpt);
   Constant *newf = Logic.CreatePrimalAndGradient(
-      fn, retType, /*constant_args*/ types, TLI, TA,
-      /*returnValue*/ false, /*dretPtr*/ false,
-      DerivativeMode::ReverseModeGradient,
-      /*additionalArg*/ Type::getInt8PtrTy(fn->getContext()), type_args,
-      uncacheable_args,
+      (ReverseCacheKey){
+            .todiff=fn,
+            .retType=retType,
+            .constant_args=types,
+            .uncacheable_args=uncacheable_args,
+            .returnUsed=false,
+            .shadowReturnUsed=false,
+            .mode=DerivativeMode::ReverseModeGradient,
+            .freeMemory=true,
+            .additionalType=Type::getInt8PtrTy(fn->getContext()),
+            .typeInfo=type_args
+      },
+      TLI, TA,
       /*map*/ &augdata, AtomicAdd);
   if (!newf)
     newf = UndefValue::get(fn->getType());

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2492,6 +2492,8 @@ DiffeGradientUtils *DiffeGradientUtils::CreateFromClone(
 
   switch (mode) {
   case DerivativeMode::ForwardMode:
+  case DerivativeMode::ForwardModeSplit:
+  case DerivativeMode::ForwardModeVector:
     prefix = "fwddiffe";
     break;
   case DerivativeMode::ReverseModeCombined:
@@ -2687,10 +2689,11 @@ Constant *GradientUtils::GetOrCreateShadowFunction(EnzymeLogic &Logic,
                         .shadowReturnUsed = false,
                         .mode = DerivativeMode::ReverseModeGradient,
                         .freeMemory = true,
+                        .AtomicAdd = AtomicAdd,
                         .additionalType = Type::getInt8PtrTy(fn->getContext()),
                         .typeInfo = type_args},
       TLI, TA,
-      /*map*/ &augdata, AtomicAdd);
+      /*map*/ &augdata);
   if (!newf)
     newf = UndefValue::get(fn->getType());
   auto cdata = ConstantStruct::get(

--- a/enzyme/Enzyme/GradientUtils.cpp
+++ b/enzyme/Enzyme/GradientUtils.cpp
@@ -2679,18 +2679,16 @@ Constant *GradientUtils::GetOrCreateShadowFunction(EnzymeLogic &Logic,
       type_args, uncacheable_args, /*forceAnonymousTape*/ true, AtomicAdd,
       PostOpt);
   Constant *newf = Logic.CreatePrimalAndGradient(
-      (ReverseCacheKey){
-            .todiff=fn,
-            .retType=retType,
-            .constant_args=types,
-            .uncacheable_args=uncacheable_args,
-            .returnUsed=false,
-            .shadowReturnUsed=false,
-            .mode=DerivativeMode::ReverseModeGradient,
-            .freeMemory=true,
-            .additionalType=Type::getInt8PtrTy(fn->getContext()),
-            .typeInfo=type_args
-      },
+      (ReverseCacheKey){.todiff = fn,
+                        .retType = retType,
+                        .constant_args = types,
+                        .uncacheable_args = uncacheable_args,
+                        .returnUsed = false,
+                        .shadowReturnUsed = false,
+                        .mode = DerivativeMode::ReverseModeGradient,
+                        .freeMemory = true,
+                        .additionalType = Type::getInt8PtrTy(fn->getContext()),
+                        .typeInfo = type_args},
       TLI, TA,
       /*map*/ &augdata, AtomicAdd);
   if (!newf)

--- a/enzyme/Enzyme/GradientUtils.h
+++ b/enzyme/Enzyme/GradientUtils.h
@@ -1496,7 +1496,8 @@ class DiffeGradientUtils : public GradientUtils {
   }
 
 public:
-  bool FreeCacheInReverse;
+  // Whether to free memory in reverse pass or split forward.
+  bool FreeMemory;
   ValueMap<const Value *, TrackingVH<AllocaInst>> differentials;
   static DiffeGradientUtils *
   CreateFromClone(EnzymeLogic &Logic, DerivativeMode mode, Function *todiff,
@@ -1785,7 +1786,7 @@ public:
                  const SubLimitType &sublimits, int i, llvm::AllocaInst *alloc,
                  llvm::ConstantInt *byteSizeOfType, llvm::Value *storeInto,
                  llvm::MDNode *InvariantMD) override {
-    if (!FreeCacheInReverse)
+    if (!FreeMemory)
       return;
     assert(reverseBlocks.find(forwardPreheader) != reverseBlocks.end());
     assert(reverseBlocks[forwardPreheader].size());

--- a/enzyme/Enzyme/Utils.h
+++ b/enzyme/Enzyme/Utils.h
@@ -247,6 +247,10 @@ static inline std::string to_string(DerivativeMode mode) {
   switch (mode) {
   case DerivativeMode::ForwardMode:
     return "ForwardMode";
+  case DerivativeMode::ForwardModeVector:
+    return "ForwardModeVector";
+  case DerivativeMode::ForwardModeSplit:
+    return "ForwardModeSplit";
   case DerivativeMode::ReverseModePrimal:
     return "ReverseModePrimal";
   case DerivativeMode::ReverseModeGradient:
@@ -296,6 +300,7 @@ static inline std::string to_string(ReturnType t) {
   case ReturnType::Void:
     return "Void";
   }
+  llvm_unreachable("illegal ReturnType");
 }
 
 #include <set>

--- a/enzyme/test/Enzyme/ReverseMode/splitSize6.ll
+++ b/enzyme/test/Enzyme/ReverseMode/splitSize6.ll
@@ -1,0 +1,48 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+
+; Function Attrs: noinline nounwind readnone uwtable
+define void @tester(double* noalias %in, double* noalias %out) {
+entry:
+  br label %loop
+
+loop:
+  %idx = phi i64 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw nsw i64 %idx, 1
+  %igep = getelementptr inbounds double, double* %in, i64 %idx
+  %ogep = getelementptr inbounds double, double* %out, i64 %idx
+  
+  %ival = load double, double* %igep
+  %sq = fmul fast double %ival, %ival
+  store double %sq, double* %ogep
+  %cmp = icmp eq i64 %inc, 6
+  br i1 %cmp, label %end, label %loop
+
+end:
+  ret void
+}
+
+define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy) {
+entry:
+  %size = call i64 (void (double*, double*)*, ...) @__enzyme_augmentsize(void (double*, double*)* nonnull @tester, metadata !"enzyme_dup", metadata !"enzyme_dup")
+  %cache = alloca i8, i64 %size, align 1
+  call void (void (double*, double*)*, ...) @__enzyme_augmentfwd(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  tail call void (void (double*, double*)*, ...) @__enzyme_reverse(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @__enzyme_augmentfwd(void (double*, double*)*, ...)
+declare i64 @__enzyme_augmentsize(void (double*, double*)*, ...)
+declare void @__enzyme_reverse(void (double*, double*)*, ...)
+
+; CHECK: define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %cache = alloca i8, i64 8, align 1
+; CHECK-NEXT:   %0 = call double* @augmented_tester(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT:   %1 = bitcast i8* %cache to double**
+; CHECK-NEXT:   store double* %0, double** %1, align 8
+; CHECK-NEXT:   %2 = bitcast i8* %cache to double**
+; CHECK-NEXT:   %3 = load double*, double** %2, align 8
+; CHECK-NEXT:   call void @diffetester(double* %x, double* %dx, double* %y, double* %dy, double* %3)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/splitSize6.ll
+++ b/enzyme/test/Enzyme/ReverseMode/splitSize6.ll
@@ -40,9 +40,9 @@ declare void @__enzyme_reverse(void (double*, double*)*, ...)
 ; CHECK-NEXT:   %cache = alloca i8, i64 8, align 1
 ; CHECK-NEXT:   %0 = call double* @augmented_tester(double* %x, double* %dx, double* %y, double* %dy)
 ; CHECK-NEXT:   %1 = bitcast i8* %cache to double**
-; CHECK-NEXT:   store double* %0, double** %1, align 8
+; CHECK-NEXT:   store double* %0, double** %1
 ; CHECK-NEXT:   %2 = bitcast i8* %cache to double**
-; CHECK-NEXT:   %3 = load double*, double** %2, align 8
+; CHECK-NEXT:   %3 = load double*, double** %2
 ; CHECK-NEXT:   call void @diffetester(double* %x, double* %dx, double* %y, double* %dy, double* %3)
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/enzyme/test/Enzyme/ReverseMode/splitSize6nofree.ll
+++ b/enzyme/test/Enzyme/ReverseMode/splitSize6nofree.ll
@@ -1,0 +1,51 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+
+; Function Attrs: noinline nounwind readnone uwtable
+define void @tester(double* noalias %in, double* noalias %out) {
+entry:
+  br label %loop
+
+loop:
+  %idx = phi i64 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw nsw i64 %idx, 1
+  %igep = getelementptr inbounds double, double* %in, i64 %idx
+  %ogep = getelementptr inbounds double, double* %out, i64 %idx
+  
+  %ival = load double, double* %igep
+  %sq = fmul fast double %ival, %ival
+  store double %sq, double* %ogep
+  %cmp = icmp eq i64 %inc, 6
+  br i1 %cmp, label %end, label %loop
+
+end:
+  ret void
+}
+
+define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy) {
+entry:
+  %size = call i64 (void (double*, double*)*, ...) @__enzyme_augmentsize(void (double*, double*)* nonnull @tester, metadata !"enzyme_dup", metadata !"enzyme_dup")
+  %cache = alloca i8, i64 %size, align 1
+  call void (void (double*, double*)*, ...) @__enzyme_augmentfwd(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  tail call void (void (double*, double*)*, ...) @__enzyme_reverse(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_nofree", metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @__enzyme_augmentfwd(void (double*, double*)*, ...)
+declare i64 @__enzyme_augmentsize(void (double*, double*)*, ...)
+declare void @__enzyme_reverse(void (double*, double*)*, ...)
+
+; CHECK: define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %cache = alloca i8, i64 8, align 1
+; CHECK-NEXT:   %0 = call double* @augmented_tester(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT:   %1 = bitcast i8* %cache to double**
+; CHECK-NEXT:   store double* %0, double** %1
+; CHECK-NEXT:   %2 = bitcast i8* %cache to double**
+; CHECK-NEXT:   %3 = load double*, double** %2
+; CHECK-NEXT:   call void @diffetester(double* %x, double* %dx, double* %y, double* %dy, double* %3)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @diffetester(double* noalias %in, double* %"in'", double* noalias %out, double* %"out'", double* %tapeArg)
+; CHECK-NOT: free

--- a/enzyme/test/Enzyme/ReverseMode/splitSize6nofree2.ll
+++ b/enzyme/test/Enzyme/ReverseMode/splitSize6nofree2.ll
@@ -1,0 +1,56 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -instsimplify -simplifycfg -S | FileCheck %s
+
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1)
+
+; Function Attrs: noinline nounwind readnone uwtable
+define void @tester(double* noalias %in, double* noalias %out) {
+entry:
+  %tmp = alloca double, i64 6
+  br label %loop
+
+loop:
+  %idx = phi i64 [ 0, %entry ], [ %inc, %loop ]
+  %inc = add nuw nsw i64 %idx, 1
+  %igep = getelementptr inbounds double, double* %in, i64 %idx
+  %tgep = getelementptr inbounds double, double* %tmp, i64 %idx
+  
+  %ival = load double, double* %igep
+  store double %ival, double* %tgep
+  %cmp = icmp eq i64 %inc, 6
+  br i1 %cmp, label %end, label %loop
+
+end:
+  %dst = bitcast double* %out to i8*
+  %src = bitcast double* %tmp to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 48, i1 false)
+  ret void
+}
+
+define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy) {
+entry:
+  %size = call i64 (void (double*, double*)*, ...) @__enzyme_augmentsize(void (double*, double*)* nonnull @tester, metadata !"enzyme_dup", metadata !"enzyme_dup")
+  %cache = alloca i8, i64 %size, align 1
+  call void (void (double*, double*)*, ...) @__enzyme_augmentfwd(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  tail call void (void (double*, double*)*, ...) @__enzyme_reverse(void (double*, double*)* nonnull @tester, metadata !"enzyme_allocated", i64 %size, metadata !"enzyme_nofree", metadata !"enzyme_tape", i8* %cache, double* %x, double* %dx, double* %y, double* %dy)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @__enzyme_augmentfwd(void (double*, double*)*, ...)
+declare i64 @__enzyme_augmentsize(void (double*, double*)*, ...)
+declare void @__enzyme_reverse(void (double*, double*)*, ...)
+
+; CHECK: define void @test_derivative(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %cache = alloca i8, i64 8, align 1
+; CHECK-NEXT:   %0 = call i8* @augmented_tester(double* %x, double* %dx, double* %y, double* %dy)
+; CHECK-NEXT:   %1 = bitcast i8* %cache to i8**
+; CHECK-NEXT:   store i8* %0, i8** %1
+; CHECK-NEXT:   %2 = bitcast i8* %cache to i8**
+; CHECK-NEXT:   %3 = load i8*, i8** %2
+; CHECK-NEXT:   call void @diffetester(double* %x, double* %dx, double* %y, double* %dy, i8* %3)
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK: define internal void @diffetester(double* noalias %in, double* %"in'", double* noalias %out, double* %"out'", i8*
+; CHECK-NOT: @free


### PR DESCRIPTION
@jedbrown @LeilaGhaffari While ideally Enzyme won't need to allocate any extra memory for your use case, the `enzyme_nofree` added here will allow you to run split mode multiple times on the same tape.