### PR TITLE
Fix gradient struct return on ARM

### DIFF
--- a/enzyme/test/Enzyme/ReverseMode/gradient-struct-ret.ll
+++ b/enzyme/test/Enzyme/ReverseMode/gradient-struct-ret.ll
@@ -1,0 +1,30 @@
+; RUN: %opt < %s %loadEnzyme -enzyme -enzyme-preopt=false -mem2reg -early-cse -instsimplify -simplifycfg -S | FileCheck %s
+
+%struct.Gradients = type { double, double }
+
+define dso_local double @muldd(double %x, double %y) #0 {
+entry:
+  %mul = fmul double %x, %y
+  ret double %mul
+}
+
+define dso_local %struct.Gradients @dmuldd(double %x, double %y) local_unnamed_addr #1 {
+entry:
+  %call = call %struct.Gradients (i8*, ...) @_Z17__enzyme_autodiffPvz(i8* bitcast (double (double, double)* @muldd to i8*), double %x, double %y)
+  ret %struct.Gradients %call
+}
+
+declare dso_local %struct.Gradients @_Z17__enzyme_autodiffPvz(i8*, ...) local_unnamed_addr #2
+
+attributes #0 = { norecurse nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+neon" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+neon" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+neon" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+; CHECK: define internal {{(dso_local )?}}{ double, double } @diffemuldd(double %x, double %y, double %differeturn)
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   %m0diffex = fmul fast double %differeturn, %y
+; CHECK-NEXT:   %m1diffey = fmul fast double %differeturn, %x
+; CHECK-NEXT:   %0 = insertvalue { double, double } undef, double %m0diffex, 0
+; CHECK-NEXT:   %1 = insertvalue { double, double } %0, double %m1diffey, 1
+; CHECK-NEXT:   ret { double, double } %1
+; CHECK-NEXT: }

--- a/enzyme/test/Integration/ReverseMode/gradient-struct-return.c
+++ b/enzyme/test/Integration/ReverseMode/gradient-struct-return.c
@@ -1,0 +1,33 @@
+// RUN: %clang -std=c11 -O0 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme -S | %lli - 
+// RUN: %clang -std=c11 -O1 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme -S | %lli - 
+// RUN: %clang -std=c11 -O2 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme -S | %lli - 
+// RUN: %clang -std=c11 -O3 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme -S | %lli - 
+// RUN: %clang -std=c11 -O0 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme --enzyme-inline=1 -S | %lli - 
+// RUN: %clang -std=c11 -O1 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme --enzyme-inline=1 -S | %lli - 
+// RUN: %clang -std=c11 -O2 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme --enzyme-inline=1 -S | %lli - 
+// RUN: %clang -std=c11 -O3 %s -S -emit-llvm -o - | %opt - %loadEnzyme -enzyme --enzyme-inline=1 -S | %lli - 
+
+#include <stdio.h>
+#include "test_utils.h"
+
+typedef struct {
+    double dx,dy;
+} Gradients;
+
+extern Gradients __enzyme_autodiff(void*, ...);
+
+double mul(double x, double y) {
+    return x * y;
+}
+Gradients dmul(double x, double y) {
+    return __enzyme_autodiff((void*)mul, x, y);
+}
+int main() {
+    double x = 1.0;
+    double y = 2.0;
+    printf("mul(x=%f,y%f)=%f\n", x, y, mul(x,y));
+    printf("ddx dmul(x=%f,y%f)=%f\n", x, y, dmul(x,y).dx);
+    printf("ddy dmul(x=%f,y%f)=%f\n", x, y, dmul(x,y).dy);
+    APPROX_EQ(dmul(x,y).dx, 2.0, 10e-10);
+    APPROX_EQ(dmul(x,y).dy, 1.0, 10e-10);
+}


### PR DESCRIPTION
When using autodiff to receive all the gradients in a struct,
the return type of `CI` on ARM emited by clang is `%struct.Foo = type { double, double }` instead of `{ double, double }` on x86. This make the following check fail: `if (diffret->getType() == CI->getType())`

To fix this we can just compare the struct layouts as follows: `CIsty->isLayoutIdentical(diffretsty)`.


All other tests  in `check-enzyme` pass on M1.