### PR TITLE
Fix C++ integration test

### DIFF
--- a/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
+++ b/enzyme/Enzyme/TypeAnalysis/TypeAnalysis.cpp
@@ -1336,7 +1336,8 @@ void TypeAnalyzer::visitGetElementPtrInst(GetElementPtrInst &gep) {
   // is valid. We could make it always valid by checking the pointer
   // operand explicitly is a pointer.
   if (direction & UP) {
-    if (gep.isInBounds() || (pointerAnalysis.Inner0() == BaseType::Pointer &&
+    if (gep.isInBounds() || (!EnzymeStrictAliasing &&
+                             pointerAnalysis.Inner0() == BaseType::Pointer &&
                              getAnalysis(&gep).Inner0() == BaseType::Pointer)) {
       for (auto &ind : gep.indices()) {
         updateAnalysis(ind, TypeTree(BaseType::Integer).Only(-1), &gep);

--- a/enzyme/test/TypeAnalysis/gepint.ll
+++ b/enzyme/test/TypeAnalysis/gepint.ll
@@ -1,4 +1,4 @@
-; RUN: %opt < %s %loadEnzyme -print-type-analysis -type-analysis-func=callee -o /dev/null | FileCheck %s
+; RUN: %opt < %s %loadEnzyme -print-type-analysis -enzyme-strict-aliasing=0 -type-analysis-func=callee -o /dev/null | FileCheck %s
 
 declare i64 @val()
 


### PR DESCRIPTION
Without strict aliasing on, this rule creates an inconsistent type info for a load of a virtual function pointer