### PR TITLE
fix handling of const return activity

### DIFF
--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3421,7 +3421,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
           assert(differetval);
           if (!gutils->isConstantValue(orig->getReturnValue())) {
             IRBuilder<> reverseB(gutils->reverseBlocks[BB].back());
-            gutils->setDiffe(orig->getReturnValue(), Constant::getNullValue(differetval->getType()), reverseB);
+            gutils->setDiffe(orig->getReturnValue(), differetval, reverseB);
           }
         } else {
           assert(dretAlloca == nullptr);

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3421,7 +3421,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
           assert(differetval);
           if (!gutils->isConstantValue(orig->getReturnValue())) {
             IRBuilder<> reverseB(gutils->reverseBlocks[BB].back());
-            gutils->setDiffe(orig->getReturnValue(), differetval, reverseB);
+            gutils->setDiffe(orig->getReturnValue(), Constant::getNullValue(differetval->getType()), reverseB);
           }
         } else {
           assert(dretAlloca == nullptr);

--- a/enzyme/Enzyme/EnzymeLogic.cpp
+++ b/enzyme/Enzyme/EnzymeLogic.cpp
@@ -3410,11 +3410,13 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
           replacedReturns[orig] = si;
         }
 
-        if (dretAlloca && !gutils->isConstantValue(orig->getReturnValue())) {
-          rb.CreateStore(gutils->invertPointerM(orig->getReturnValue(), rb),
+        if (key.retType == DIFFE_TYPE::DUP_ARG || 
+	    key.retType == DIFFE_TYPE::DUP_NONEED) {
+        	if (dretAlloca) {
+          		rb.CreateStore(gutils->invertPointerM(orig->getReturnValue(), rb),
                          dretAlloca);
-        }
-        if (key.retType == DIFFE_TYPE::OUT_DIFF) {
+		}
+        } else if (key.retType == DIFFE_TYPE::OUT_DIFF) {
           assert(orig->getReturnValue());
           assert(differetval);
           if (!gutils->isConstantValue(orig->getReturnValue())) {
@@ -3422,7 +3424,7 @@ Function *EnzymeLogic::CreatePrimalAndGradient(
             gutils->setDiffe(orig->getReturnValue(), differetval, reverseB);
           }
         } else {
-          assert(retAlloca == nullptr);
+          assert(dretAlloca == nullptr);
         }
 
         rb.CreateBr(gutils->reverseBlocks[BB].front());


### PR DESCRIPTION
Fixes the following testcase, where the return value is set to Const.
Once we exposed that for __enzyme we should add a testcase.
Still have to fix the formating.

   17 #[differentiate(d_test, Reverse, All(Active), Constant, false)]
   18 fn test(x: f64) -> f64 {
   19     2.0 * x
   20 }
